### PR TITLE
Fix escrow actor order interface

### DIFF
--- a/frontend/api/escrow/service.did.js
+++ b/frontend/api/escrow/service.did.js
@@ -67,7 +67,78 @@ export const idlFactory = ({ IDL }) => {
   });
   const StablecoinInfo = IDL.Record({ canisterId: IDL.Text, symbol: IDL.Text, decimals: IDL.Nat8, fee: IDL.Nat64, enabled: IDL.Bool });
 
+  const Status = IDL.Variant({
+    new: IDL.Null,
+    deposited: IDL.Null,
+    delivered: IDL.Null,
+    received: IDL.Null,
+    released: IDL.Null,
+    refunded: IDL.Null,
+    closed: IDL.Null,
+    canceled: IDL.Null,
+  });
+  const Balance = IDL.Variant({ e8s: IDL.Nat64, e6s: IDL.Nat64 });
+  const EscrowAccount = IDL.Record({ index: IDL.Nat, id: IDL.Text });
+  const Log = IDL.Record({
+    ltime: IDL.Int,
+    log: IDL.Text,
+    logger: IDL.Variant({ buyer: IDL.Null, seller: IDL.Null, escrow: IDL.Null }),
+  });
+  const Comment = IDL.Record({ user: IDL.Principal, comment: IDL.Text, ctime: IDL.Int });
+  const Order = IDL.Record({
+    id: IDL.Nat,
+    buyer: IDL.Principal,
+    seller: IDL.Principal,
+    memo: IDL.Text,
+    amount: IDL.Nat64,
+    currency: Currency,
+    account: EscrowAccount,
+    blockin: IDL.Nat64,
+    blockout: IDL.Nat64,
+    createtime: IDL.Int,
+    lockedby: IDL.Principal,
+    status: Status,
+    updatetime: IDL.Int,
+    expiration: IDL.Int,
+    comments: IDL.Vec(Comment),
+    logs: IDL.Vec(Log),
+  });
+  const NewOrder = IDL.Record({ seller: IDL.Principal, memo: IDL.Text, amount: IDL.Nat64, currency: Currency, expiration: IDL.Int });
+  const NewSellOrder = IDL.Record({ buyer: IDL.Principal, memo: IDL.Text, amount: IDL.Nat64, currency: Currency, expiration: IDL.Int });
+  const FreeItemClaim = IDL.Record({
+    id: IDL.Nat,
+    itemId: IDL.Nat,
+    itemName: IDL.Text,
+    seller: IDL.Principal,
+    buyer: IDL.Principal,
+    ctime: IDL.Int,
+    comments: IDL.Vec(Comment),
+    closedAt: IDL.Opt(IDL.Int),
+    canceledAt: IDL.Opt(IDL.Int),
+  });
+  const Review = IDL.Record({ id: IDL.Nat, orderId: IDL.Nat, reviewer: IDL.Principal, target: IDL.Principal, rating: IDL.Nat, comment: IDL.Text, ctime: IDL.Int });
+  const UserStats = IDL.Record({ heartsReceived: IDL.Nat, salesCompleted: IDL.Nat, purchasesCompleted: IDL.Nat, reviewCount: IDL.Nat, ratingSum: IDL.Nat, avgRating: IDL.Float64 });
+
   return IDL.Service({
+
+    buy: IDL.Func([NewOrder], [Result(IDL.Nat)], []),
+    sell: IDL.Func([NewSellOrder], [Result(IDL.Nat)], []),
+    create: IDL.Func([NewOrder], [Result(IDL.Nat)], []),
+    deposit: IDL.Func([IDL.Nat], [Result(IDL.Nat)], []),
+    deliver: IDL.Func([IDL.Nat], [Result(IDL.Nat)], []),
+    receive: IDL.Func([IDL.Nat], [Result(IDL.Nat)], []),
+    release: IDL.Func([IDL.Nat], [Result(IDL.Nat)], []),
+    close: IDL.Func([IDL.Nat], [Result(IDL.Nat)], []),
+    cancel: IDL.Func([IDL.Nat], [Result(IDL.Nat)], []),
+    comment: IDL.Func([IDL.Nat, IDL.Text], [Result(IDL.Nat)], []),
+    getOrders: IDL.Func([], [IDL.Vec(Order)], ['query']),
+    getOrder: IDL.Func([IDL.Nat], [IDL.Opt(Order)], ['query']),
+    getAllOrders: IDL.Func([IDL.Nat], [IDL.Vec(Order)], ['query']),
+    getMyAccountId: IDL.Func([IDL.Nat], [IDL.Text], ['query']),
+    getAccountId: IDL.Func([IDL.Nat], [IDL.Text], ['query']),
+    getBalanceBySub: IDL.Func([IDL.Nat, Currency], [Balance], []),
+    accountBalance: IDL.Func([IDL.Text, Currency], [Balance], []),
+    getOrderBalance: IDL.Func([IDL.Nat], [Balance], []),
     listItem: IDL.Func([NewItem], [Result(IDL.Nat)], []),
     updateItem: IDL.Func([IDL.Nat, UpdateItem], [Result(IDL.Nat)], []),
     deleteItem: IDL.Func([IDL.Nat], [Result(IDL.Nat)], []),
@@ -81,6 +152,18 @@ export const idlFactory = ({ IDL }) => {
     getService: IDL.Func([IDL.Nat], [IDL.Opt(ServiceInfo)], ['query']),
     listServices: IDL.Func([], [IDL.Vec(ServiceInfo)], ['query']),
     getSupportedStablecoins: IDL.Func([], [IDL.Vec(StablecoinInfo)], ['query']),
+
+    changeItemStatus: IDL.Func([IDL.Nat, ItemStatus], [Result(IDL.Nat)], []),
+    claimFreeItem: IDL.Func([IDL.Nat], [Result(IDL.Nat)], []),
+    getMyFreeItemClaims: IDL.Func([], [IDL.Vec(FreeItemClaim)], ['query']),
+    getMyBuyerFreeItemClaims: IDL.Func([], [IDL.Vec(FreeItemClaim)], ['query']),
+    commentOnClaim: IDL.Func([IDL.Nat, IDL.Text], [Result(IDL.Nat)], []),
+    closeClaim: IDL.Func([IDL.Nat], [Result(IDL.Nat)], []),
+    cancelClaim: IDL.Func([IDL.Nat], [Result(IDL.Nat)], []),
+    heartUser: IDL.Func([IDL.Principal, IDL.Nat], [Result(IDL.Nat)], []),
+    leaveReview: IDL.Func([IDL.Nat, IDL.Nat, IDL.Text], [Result(IDL.Nat)], []),
+    getUserReviews: IDL.Func([IDL.Principal], [IDL.Vec(Review)], ['query']),
+    getUserStats: IDL.Func([IDL.Principal], [UserStats], ['query']),
   });
 };
 export const init = ({ IDL }) => [];


### PR DESCRIPTION
### Motivation
- The Orders UI crashed with `e.getOrders is not a function` because the frontend escrow actor IDL lacked the Order-related types and methods exposed by the backend.
- Keep the frontend actor Candid in sync with backend service definitions so UI components can call order, claim and reputation APIs.

### Description
- Extended `frontend/api/escrow/service.did.js` with missing Candid type definitions: `Status`, `Balance`, `EscrowAccount`, `Log`, `Comment`, `Order`, `NewOrder`, `NewSellOrder`, `FreeItemClaim`, `Review`, and `UserStats`.
- Registered order lifecycle and balance methods on the frontend actor: `buy`, `sell`, `create`, `deposit`, `deliver`, `receive`, `release`, `close`, `cancel`, `comment`, `getOrders`, `getOrder`, `getAllOrders`, `getBalanceBySub`, `accountBalance`, and `getOrderBalance`.
- Added free-item claim and reputation APIs used by the Orders screens: `changeItemStatus`, `claimFreeItem`, `getMyFreeItemClaims`, `getMyBuyerFreeItemClaims`, `commentOnClaim`, `closeClaim`, `cancelClaim`, `heartUser`, `leaveReview`, `getUserReviews`, and `getUserStats`.

### Testing
- Ran the production build with `npm run build` (runs `tsc` and `vite build`), which completed successfully (bundle emitted and build finished).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a550543fc1483309076ae3ddb014209)