### PR TITLE
Add searchItemsByKeywords query API

### DIFF
--- a/backend/main.mo
+++ b/backend/main.mo
@@ -1545,6 +1545,48 @@ persistent actor class EscrowService() = this {
         Page.getArrayPage(titems, page, default_page_size)
     };
 
+    private func itemContainsKeyword(item : ItemTypes.Item, keyword : Text) : Bool {
+        let normalizedKeyword = Text.toLowercase(keyword);
+        if (normalizedKeyword == "") {
+            false
+        } else if (Text.contains(Text.toLowercase(item.name), #text normalizedKeyword)) {
+            true
+        } else if (Text.contains(Text.toLowercase(item.description), #text normalizedKeyword)) {
+            true
+        } else {
+            Array.find<Text>(
+                item.tags,
+                func(tag) {
+                    Text.contains(Text.toLowercase(tag), #text normalizedKeyword)
+                },
+            ) != null
+        }
+    };
+
+    private func itemMatchesKeywords(item : ItemTypes.Item, keywords : [Text]) : Bool {
+        Array.find<Text>(
+            keywords,
+            func(keyword) {
+                itemContainsKeyword(item, keyword)
+            },
+        ) != null
+    };
+
+    public query func searchItemsByKeywords(keywords : [Text], page : Nat) : async [ItemTypes.Item] {
+        let titems = items.getItems();
+        let matchedItems = Array.filter<ItemTypes.Item>(
+            titems,
+            func(item) {
+                item.status == #list and itemMatchesKeywords(item, keywords)
+            },
+        );
+        let sortedItems = Array.sort<ItemTypes.Item>(
+            matchedItems,
+            func(a, b) { Int.compare(Int.abs(b.listime), Int.abs(a.listime)) },
+        );
+        Page.getArrayPage(sortedItems, page, default_page_size)
+    };
+
     public query func getItems(page : Nat) : async [ItemTypes.Item] {
         let titems = items.getItems();
         let sortedItems = Array.sort<ItemTypes.Item>(

--- a/frontend/api/escrow/service.did.d.ts
+++ b/frontend/api/escrow/service.did.d.ts
@@ -53,6 +53,7 @@ export interface _SERVICE {
   getItems: ActorMethod<[bigint], Item[]>;
   getMyItems: ActorMethod<[bigint], Item[]>;
   searchItems: ActorMethod<[ItemType, bigint], Item[]>;
+  searchItemsByKeywords: ActorMethod<[string[], bigint], Item[]>;
   createService: ActorMethod<[NewServiceInfo], Result<ServiceId>>;
   updateService: ActorMethod<[ServiceId, UpdateServiceInfo], Result<ServiceId>>;
   deleteService: ActorMethod<[ServiceId], Result<ServiceId>>;

--- a/frontend/api/escrow/service.did.js
+++ b/frontend/api/escrow/service.did.js
@@ -84,6 +84,7 @@ export const idlFactory = ({ IDL }) => {
     getItems: IDL.Func([IDL.Nat], [IDL.Vec(Item)], ['query']),
     getMyItems: IDL.Func([IDL.Nat], [IDL.Vec(Item)], ['query']),
     searchItems: IDL.Func([ItemType, IDL.Nat], [IDL.Vec(Item)], ['query']),
+    searchItemsByKeywords: IDL.Func([IDL.Vec(IDL.Text), IDL.Nat], [IDL.Vec(Item)], ['query']),
     createService: IDL.Func([NewServiceInfo], [Result(IDL.Nat)], []),
     updateService: IDL.Func([IDL.Nat, NewServiceInfo], [Result(IDL.Nat)], []),
     deleteService: IDL.Func([IDL.Nat], [Result(IDL.Nat)], []),


### PR DESCRIPTION
### Motivation
- Provide a server-side keyword search over marketplace items so clients can find listings by words in title/name, description, or tags.
- Keep search results consistent with existing listing behaviour by only returning listed items, paginating with `default_page_size`, and sorting newest-first.

### Description
- Add case-insensitive matching helpers `itemContainsKeyword` and `itemMatchesKeywords` and a new query `searchItemsByKeywords(keywords : [Text], page : Nat)` in `backend/main.mo` that filters `items.getItems()` by `status == #list`, matches any provided keyword, sorts by `listime` descending, and paginates with `Page.getArrayPage`.
- Treat empty keywords as non-matches so callers must supply non-empty terms to match content.
- Expose the new endpoint in the frontend service definitions by adding `searchItemsByKeywords: ActorMethod<[string[], bigint], Item[]>` to `frontend/api/escrow/service.did.d.ts` and `searchItemsByKeywords: IDL.Func([IDL.Vec(IDL.Text), IDL.Nat], [IDL.Vec(Item)], ['query'])` to `frontend/api/escrow/service.did.js`.

### Testing
- Ran `npm run build`, which executed `tsc` and `vite build`, and the build completed successfully.
- Ran `git diff --check` and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a563dae4c7c833081e36c095c1ce415)