### PR TITLE
feat: clarify cancel and refund UX

### DIFF
--- a/frontend/components/orders/OrderDetail.tsx
+++ b/frontend/components/orders/OrderDetail.tsx
@@ -1,262 +1,495 @@
 import * as React from 'react';
 import moment from 'moment';
-
-import { ORDER_STATUS_CANCELED, ORDER_STATUS_CLOSED, ORDER_STATUS_DELIVERED, ORDER_STATUS_DEPOSITED, ORDER_STATUS_NEW, ORDER_STATUS_RECEIVED, ORDER_STATUS_REFUNDED, ORDER_STATUS_RELEASED } from '../../lib/constants';
 import { toast } from 'react-toastify';
 
+import {
+    ORDER_STATUS_CANCELED,
+    ORDER_STATUS_CLOSED,
+    ORDER_STATUS_DELIVERED,
+    ORDER_STATUS_DEPOSITED,
+    ORDER_STATUS_NEW,
+    ORDER_STATUS_RECEIVED,
+    ORDER_STATUS_REFUNDED,
+    ORDER_STATUS_RELEASED,
+} from '../../lib/constants';
+import {
+    canCancelOrder,
+    canCloseOrder,
+    getOrderStatus,
+    needsProgressConfirmation,
+    orderProgressStep,
+    refundModeForOrder,
+} from '../../lib/orderPolicy';
+import { currencySymbol } from '../../lib/currencyUtils';
 import { useEscrow, useGlobalContext, useLoading } from '../Store';
 import PrincipalName from '../PrincipalName';
 import CommentButton from './CommentButton';
 import Comments from './CommentList';
 import ReviewForm from '../profile/ReviewForm';
-import { currencyBase, currencySymbol } from '../../lib/currencyUtils';
 
+type PendingAction = 'cancel' | 'refund' | 'release' | 'close' | null;
 
+const STATUS_STYLES: Record<string, string> = {
+    new: 'border-sky-200 bg-sky-50 text-sky-700',
+    deposited: 'border-blue-200 bg-blue-50 text-blue-700',
+    delivered: 'border-amber-200 bg-amber-50 text-amber-700',
+    received: 'border-violet-200 bg-violet-50 text-violet-700',
+    released: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+    canceled: 'border-rose-200 bg-rose-50 text-rose-700',
+    refunded: 'border-orange-200 bg-orange-50 text-orange-700',
+    closed: 'border-slate-200 bg-slate-100 text-slate-600',
+};
 
-export default (props) => {
+function currencyDecimals(currency: Record<string, any>): number {
+    const key = Object.keys(currency)[0];
+    if (key === 'ICP') return 8;
+    if (key === 'ICET') return 6;
+    if (key === 'ICRC1') return Number(currency.ICRC1?.decimals ?? 8);
+    return 8;
+}
 
+function formatUnits(raw: bigint | number | string, decimals: number, maxFractionDigits = 8): string {
+    try {
+        const value = BigInt(raw);
+        const safeDecimals = Math.max(0, Math.min(decimals, 30));
+        const scale = 10n ** BigInt(safeDecimals);
+        const whole = value / scale;
+        const fractionUnits = value % scale;
+        const groupedWhole = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(whole);
+        if (fractionUnits === 0n || safeDecimals === 0) return groupedWhole;
+        const fraction = fractionUnits
+            .toString()
+            .padStart(safeDecimals, '0')
+            .slice(0, Math.min(safeDecimals, maxFractionDigits))
+            .replace(/0+$/, '');
+        return fraction ? `${groupedWhole}.${fraction}` : groupedWhole;
+    } catch {
+        return 'Unavailable';
+    }
+}
 
-    const { state: {
-        principal
-    } } = useGlobalContext();
-    const escrow = useEscrow();
+function rawBalance(result: any): bigint {
+    if (result && result.e8s !== undefined) return BigInt(result.e8s);
+    if (result && result.e6s !== undefined) return BigInt(result.e6s);
+    throw new Error('Escrow returned an unsupported balance response.');
+}
 
-    const [order] = React.useState(props.order);
-    const [comments, setComments] = React.useState(props.order.comments);
-    const [status, setStatus] = React.useState<string>(Object.getOwnPropertyNames(order.status)[0])
+function resultError(result: any): string {
+    if (!result || result.err === undefined) return 'Action failed';
+    if (typeof result.err === 'string') return result.err;
+    try {
+        return JSON.stringify(result.err, (_, value) => typeof value === 'bigint' ? value.toString() : value);
+    } catch {
+        return String(result.err);
+    }
+}
 
-    const currency = currencySymbol(order.currency);
-    const es = currencyBase(order.currency);
-    const amount = parseInt(order.amount) / es;
-    const isFreeOrder = amount === 0;
-    const amountLabel = isFreeOrder ? "FREE" : `${amount} (${currency})`;
-    const canCloseOrder = status != ORDER_STATUS_CLOSED && status != ORDER_STATUS_CANCELED && status != ORDER_STATUS_REFUNDED;
-    
-    const activeStep = isFreeOrder ? 2 : (
-        status == ORDER_STATUS_NEW ? 1 :
-        status == ORDER_STATUS_DEPOSITED ? 2 :
-            status == ORDER_STATUS_DELIVERED ? 3 :
-                status == ORDER_STATUS_RECEIVED ? 4 :
-                   ( status == ORDER_STATUS_RELEASED || status == ORDER_STATUS_CLOSED) ? 5 : 1
+function ConfirmAction({
+    open,
+    title,
+    description,
+    confirmLabel,
+    danger = false,
+    busy,
+    onCancel,
+    onConfirm,
+}: {
+    open: boolean;
+    title: string;
+    description: string;
+    confirmLabel: string;
+    danger?: boolean;
+    busy: boolean;
+    onCancel: () => void;
+    onConfirm: () => void;
+}) {
+    if (!open) return null;
+    return (
+        <div className="fixed inset-0 z-[70] flex items-center justify-center bg-slate-950/45 p-4" role="dialog" aria-modal="true" aria-label={title}>
+            <div className="w-full max-w-md rounded-2xl border border-slate-200 bg-white p-5 shadow-2xl">
+                <h3 className="text-lg font-semibold text-slate-950">{title}</h3>
+                <p className="mt-2 text-sm leading-6 text-slate-600">{description}</p>
+                <div className="mt-5 flex justify-end gap-2">
+                    <button
+                        type="button"
+                        disabled={busy}
+                        onClick={onCancel}
+                        className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+                    >
+                        Keep order
+                    </button>
+                    <button
+                        type="button"
+                        disabled={busy}
+                        onClick={onConfirm}
+                        className={`rounded-lg px-4 py-2 text-sm font-semibold text-white disabled:opacity-50 ${danger ? 'bg-rose-600 hover:bg-rose-700' : 'bg-cyan-700 hover:bg-cyan-800'}`}
+                    >
+                        {busy ? 'Submitting…' : confirmLabel}
+                    </button>
+                </div>
+            </div>
+        </div>
     );
+}
 
+export default function OrderDetail(props) {
+    const { state: { principal } } = useGlobalContext();
+    const escrow = useEscrow();
     const { setLoading } = useLoading();
-    const [confirmed, setConfirmed] = React.useState(false)
-    const [balance, setBalance] = React.useState(0)
-    const [reviewSubmitted, setReviewSubmitted] = React.useState(false)
 
+    const [order, setOrder] = React.useState(props.order);
+    const [comments, setComments] = React.useState(props.order.comments ?? []);
+    const [status, setStatus] = React.useState<string>(getOrderStatus(props.order.status));
+    const [confirmed, setConfirmed] = React.useState(false);
+    const [balance, setBalance] = React.useState<bigint | null>(null);
+    const [balanceLoading, setBalanceLoading] = React.useState(false);
+    const [balanceError, setBalanceError] = React.useState('');
+    const [busyAction, setBusyAction] = React.useState<string>('');
+    const [pendingAction, setPendingAction] = React.useState<PendingAction>(null);
+    const [reviewSubmitted, setReviewSubmitted] = React.useState(false);
 
-    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-        setConfirmed(event.target.checked);
-    };
+    const principalText = principal?.toString?.() ?? '';
+    const isBuyer = principalText === order.buyer.toString();
+    const isSeller = principalText === order.seller.toString();
+    const decimals = currencyDecimals(order.currency);
+    const currency = currencySymbol(order.currency);
+    const amountRaw = BigInt(order.amount ?? 0);
+    const isFreeOrder = amountRaw === 0n;
+    const amountLabel = isFreeOrder ? 'FREE' : `${formatUnits(amountRaw, decimals)} ${currency}`;
+    const balanceLabel = balance === null ? 'Unavailable' : `${formatUnits(balance, decimals)} ${currency}`;
+    const hasEscrowBalance = balance !== null && balance > 0n;
+    const canCancel = !isFreeOrder && canCancelOrder(status, isBuyer, isSeller);
+    const refundMode = isFreeOrder ? null : refundModeForOrder(status, isBuyer, isSeller);
+    const canStandaloneRefund = Boolean(refundMode && hasEscrowBalance && !canCancel);
+    const canClose = canCloseOrder(status, isSeller);
+    const needsConfirm = !isFreeOrder && needsProgressConfirmation(status, isBuyer, isSeller);
+    const activeStep = orderProgressStep(status);
+    const statusStyle = STATUS_STYLES[status] ?? 'border-slate-200 bg-slate-50 text-slate-600';
 
-    const loadOrder = () => {
-        // console.log("reloading order")
-        setLoading(true);
-        escrow.getOrder(order.id).then(res=>{
-            setLoading(false)
-            // console.log(res[0]);
-            if(res[0]){setComments(res[0].comments)}
- 
-        });
-    };
+    React.useEffect(() => {
+        setOrder(props.order);
+        setComments(props.order.comments ?? []);
+        setStatus(getOrderStatus(props.order.status));
+        setConfirmed(false);
+    }, [props.order]);
 
-    function fetchBalance() {
-        setLoading(true);
-        const currencyKey = Object.keys(order.currency)[0];
-        // For ICRC-1 orders, use getOrderBalance which resolves the correct subaccount.
-        const balancePromise = currencyKey === 'ICRC1'
-            ? escrow.getOrderBalance(order.id)
-            : escrow.accountBalance(order.account.id, order.currency);
-        balancePromise.then(res => {
-            const base = currencyBase(order.currency);
-            if (res["e8s"] !== undefined) {
-                setBalance(parseInt(res["e8s"]) / base);
-            } else if (res["e6s"] !== undefined) {
-                setBalance(parseInt(res["e6s"]) / base);
-            } else {
-                setBalance(0);
+    const refreshOrder = React.useCallback(async () => {
+        try {
+            const response = await escrow.getOrder(order.id);
+            const fresh = response?.[0];
+            if (fresh) {
+                setOrder(fresh);
+                setComments(fresh.comments ?? []);
+                setStatus(getOrderStatus(fresh.status));
+                setConfirmed(false);
+                props.onChanged?.(fresh);
+                return fresh;
             }
+        } catch {
+            // A successful mutation should not be reported as failed only because refresh failed.
+        }
+        return null;
+    }, [escrow, order.id, props]);
+
+    const refreshBalance = React.useCallback(async () => {
+        if (isFreeOrder) {
+            setBalance(0n);
+            setBalanceError('');
+            return;
+        }
+        setBalanceLoading(true);
+        setBalanceError('');
+        try {
+            const result = await escrow.getOrderBalance(order.id);
+            setBalance(rawBalance(result));
+        } catch (error: any) {
+            setBalance(null);
+            setBalanceError(error?.message ?? 'Unable to load escrow balance.');
+        } finally {
+            setBalanceLoading(false);
+        }
+    }, [escrow, isFreeOrder, order.id]);
+
+    React.useEffect(() => {
+        void refreshBalance();
+    }, [refreshBalance, status]);
+
+    async function runAction(
+        actionName: string,
+        fn: () => Promise<any>,
+        successMessage: string,
+        fallbackStatus?: string,
+    ) {
+        setBusyAction(actionName);
+        setLoading(true);
+        try {
+            const result = await fn();
+            if (result && Object.prototype.hasOwnProperty.call(result, 'ok')) {
+                if (fallbackStatus) setStatus(fallbackStatus);
+                setConfirmed(false);
+                setPendingAction(null);
+                toast.success(successMessage);
+                await refreshOrder();
+                await refreshBalance();
+                return true;
+            }
+            toast.error(resultError(result));
+            return false;
+        } catch (error: any) {
+            toast.error(error?.message ?? 'Action failed');
+            return false;
+        } finally {
+            setBusyAction('');
             setLoading(false);
-        });
-    };
-    const deposit = () => {
-        setLoading(true)
-        escrow.deposit(order.id).then(res => {
-            if (res["ok"]) {
-                toast.success("Status has changed");
-                setStatus(ORDER_STATUS_DEPOSITED)
-            } else {
-                toast.error(res["err"])
+        }
+    }
+
+    const deposit = () => runAction('deposit', () => escrow.deposit(order.id), 'Deposit confirmed.', ORDER_STATUS_DEPOSITED);
+    const deliver = () => runAction('deliver', () => escrow.deliver(order.id), 'Delivery confirmed.', ORDER_STATUS_DELIVERED);
+    const receive = () => runAction('receive', () => escrow.receive(order.id), 'Receipt confirmed.', ORDER_STATUS_RECEIVED);
+    const release = () => runAction('release', () => escrow.release(order.id), 'Funds released to seller.', ORDER_STATUS_RELEASED);
+    const cancelOrder = () => runAction(
+        'cancel',
+        () => escrow.cancel(order.id),
+        'Order canceled. Any refundable escrow balance was returned to the buyer by the canister.',
+        ORDER_STATUS_CANCELED,
+    );
+    const refund = () => runAction(
+        'refund',
+        () => escrow.refund(order.id),
+        'Refund submitted. The escrow balance has been returned to the buyer, less applicable ledger fees.',
+    );
+    const closeOrder = () => runAction('close', () => escrow.close(order.id), 'Order closed.', ORDER_STATUS_CLOSED);
+
+    function actionDialogCopy() {
+        if (pendingAction === 'cancel') {
+            return {
+                title: status === ORDER_STATUS_DEPOSITED ? 'Cancel and refund buyer?' : 'Cancel this order?',
+                description: status === ORDER_STATUS_DEPOSITED
+                    ? `The canister will cancel the order and attempt to return the current escrow balance (${balanceLabel}) to the buyer. Ledger fees may apply.`
+                    : `If funds are already in escrow, cancellation automatically attempts to return the refundable balance to the buyer. Current escrow balance: ${balanceLabel}.`,
+                confirmLabel: status === ORDER_STATUS_DEPOSITED ? 'Cancel & refund' : 'Cancel order',
+                danger: true,
+                run: cancelOrder,
             };
-            setLoading(false);
-        })
-    };
+        }
+        if (pendingAction === 'refund') {
+            return {
+                title: refundMode === 'buyer_recovery' ? 'Recover remaining escrow balance?' : 'Refund buyer?',
+                description: `Return the current escrow balance (${balanceLabel}) to the buyer. The canister deducts applicable ledger fees. This transfer cannot be undone.`,
+                confirmLabel: refundMode === 'buyer_recovery' ? 'Recover balance' : 'Refund buyer',
+                danger: true,
+                run: refund,
+            };
+        }
+        if (pendingAction === 'release') {
+            return {
+                title: 'Release funds to seller?',
+                description: `Release the remaining escrow balance to the seller. Once released, this order is no longer refundable through the normal refund path.`,
+                confirmLabel: 'Release funds',
+                danger: false,
+                run: release,
+            };
+        }
+        if (pendingAction === 'close') {
+            return {
+                title: 'Close this order?',
+                description: `Closing finalizes this workflow. Review the escrow balance (${balanceLabel}) before continuing; any remaining funds are handled by the canister's close logic.`,
+                confirmLabel: 'Close order',
+                danger: false,
+                run: closeOrder,
+            };
+        }
+        return null;
+    }
 
-    const deliver = () => {
-        setLoading(true);
-        escrow.deliver(order.id).then(res => {
-            if (res["ok"]) {
-                toast.success("Status has changed");
-                setStatus(ORDER_STATUS_DELIVERED)
-            } else {
-                toast.error(res["err"])
-            }
-            setLoading(false);
-        })
-    };
-    const receive = () => {
-        setLoading(true);
-        escrow.receive(order.id).then(res => {
-            if (res["ok"]) {
-                toast.success("Status has changed");
-                setStatus(ORDER_STATUS_RECEIVED)
-            } else {
-                toast.error(res["err"])
-            }
-            setLoading(false);
-        })
-    };
-    const release = () => {
-        setLoading(true);
-        escrow.release(order.id).then(res => {
-            if (res["ok"]) {
-                toast.success("Status has changed, check your fund ");
-                setStatus(ORDER_STATUS_RELEASED)
-            } else {
-                toast.error(res["err"])
-            }
-            setLoading(false);
-        })
-    };
-    const cancelOrder = () => {
-        setLoading(true);
-        escrow.cancel(order.id).then(res => {
-            if (res["ok"]) {
-                toast.success("the order has been canceled");
-                setStatus(ORDER_STATUS_CANCELED)
-            } else {
-                toast.error(res["err"])
-            }
-            setLoading(false);
-        })
-    };  
-
-    const closeOrder = () => {
-        setLoading(true);
-        escrow.close(order.id).then(res => {
-            if (res["ok"]) {
-                toast.success("the order has been closed");
-                setStatus(ORDER_STATUS_CLOSED)
-            } else {
-                toast.error(res["err"])
-            }
-            setLoading(false);
-        })
-    };
-
+    const dialog = actionDialogCopy();
 
     return (
-        <div className="space-y-4 rounded-lg border border-slate-200 bg-white p-4">
-            <div className="grid grid-cols-1 gap-2 text-sm sm:grid-cols-2">
-                <div className="rounded-md bg-slate-50 px-3 py-2 text-slate-900"><span className="font-semibold text-slate-800">Create Time:</span> {moment.unix(parseInt(order.createtime) / 1000000000).format("YYYY-MM-DD hh:mm")}</div>
-                <div className="rounded-md bg-slate-50 px-3 py-2 text-slate-900"><span className="font-semibold text-slate-800">ID:</span> {parseInt(order.id)}</div>
-                <div className="rounded-md bg-slate-50 px-3 py-2 text-slate-900"><span className="font-semibold text-slate-800">Amount:</span> {amountLabel}</div>
-                {!isFreeOrder && <div className="rounded-md bg-slate-50 px-3 py-2 text-slate-900 break-all"><span className="font-semibold text-slate-800">Escrow Account:</span> {order.account.id}</div>}
-                <div className="rounded-md bg-slate-50 px-3 py-2 text-slate-900 sm:col-span-2"><span className="font-semibold text-slate-800">Buyer {order.buyer.toString() == principal.toString() ? "(you)" : ""}:</span> <PrincipalName principal={order.buyer} /></div>
-                <div className="rounded-md bg-slate-50 px-3 py-2 text-slate-900 sm:col-span-2"><span className="font-semibold text-slate-800">Seller {order.seller.toString() == principal.toString() ? "(you)" : ""}:</span> <PrincipalName principal={order.seller} /></div>
-                {!isFreeOrder && (
-                    <div className="rounded-md bg-slate-50 px-3 py-2 text-slate-900 sm:col-span-2">
-                        <span className="font-semibold text-slate-800">Balance:</span> {balance}
-                        <button
-                            type="button"
-                            onClick={fetchBalance}
-                            className="ml-2 rounded-md border border-cyan-600 px-2 py-1 text-xs font-semibold text-cyan-700 transition hover:bg-cyan-50"
-                        >
-                            Check
-                        </button>
+        <div className="space-y-5 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm sm:p-5">
+            <div className="flex flex-wrap items-start justify-between gap-3 border-b border-slate-100 pb-4">
+                <div>
+                    <div className="flex flex-wrap items-center gap-2">
+                        <h2 className="text-lg font-semibold text-slate-950">Order #{String(order.id)}</h2>
+                        <span className={`rounded-full border px-2.5 py-1 text-xs font-semibold capitalize ${statusStyle}`}>{status}</span>
                     </div>
-                )}
-            </div>
-
-            <div>
-                <p className="mb-2 text-sm font-semibold text-slate-700">Status</p>
-                {isFreeOrder ? (
-                    <div className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-800">
-                        <p className="font-semibold">Free Item Claim</p>
-                        <p className="mt-1 text-xs">
-                            {principal?.toString() === order.seller.toString() 
-                                ? "Go back to the item to set status: Hold, Sold, or Relist."
-                                : "Waiting for seller to set item status (Hold, Sold, or Relist)."}
-                        </p>
-                    </div>
-                ) : (
-                    <>
-                        <div className="grid grid-cols-2 gap-2 text-xs sm:grid-cols-5">
-                            {[
-                                { label: 'New', step: 1 },
-                                { label: 'Deposited', step: 2 },
-                                { label: 'Delivered', step: 3 },
-                                { label: 'Received', step: 4 },
-                                { label: 'Close', step: 5 },
-                            ].map((s) => (
-                                <div
-                                    key={s.step}
-                                    className={`rounded-md px-3 py-2 text-center font-medium ${activeStep >= s.step ? 'bg-cyan-600 text-white' : 'bg-slate-100 text-slate-600'}`}
-                                >
-                                    {s.label}
-                                </div>
-                            ))}
-                        </div>
-                    </>
-                )}
-            </div>
-
-            <div className="space-y-2">
-                {!isFreeOrder && (
-                    <>
-                        {status == ORDER_STATUS_NEW && principal.toString() == order.buyer.toString() && <div className="rounded-md border border-sky-200 bg-sky-50 px-3 py-2 text-sm text-sky-800">Before change the order status, make sure you already deposit [{amount} {currency}] to the escrow account {order.account.id}</div>}
-                        {status == ORDER_STATUS_NEW && principal.toString() == order.seller.toString() && <div className="rounded-md border border-sky-200 bg-sky-50 px-3 py-2 text-sm text-sky-800">Please wait for buyer to deposit fund [{amount} {currency}] to escrow account, or you can cancel it</div>}
-                        {status == ORDER_STATUS_DEPOSITED && principal.toString() == order.seller.toString() && <div className="rounded-md border border-sky-200 bg-sky-50 px-3 py-2 text-sm text-sky-800">Have you deliver {order.memo} to buyer?</div>}
-                        {status == ORDER_STATUS_DEPOSITED && principal.toString() == order.buyer.toString() && <div className="rounded-md border border-sky-200 bg-sky-50 px-3 py-2 text-sm text-sky-800">Before the following steps, please wait for seller to deliver {order.memo} to you.</div>}
-                        {status == ORDER_STATUS_DELIVERED && principal.toString() == order.buyer.toString() && <div className="rounded-md border border-sky-200 bg-sky-50 px-3 py-2 text-sm text-sky-800">Are you sure you receive {order.memo} from seller? Once you change order status, the fund will be released to seller and can't be refunded.</div>}
-                        {status == ORDER_STATUS_RECEIVED && principal.toString() == order.seller.toString() && <div className="rounded-md border border-sky-200 bg-sky-50 px-3 py-2 text-sm text-sky-800">Now you can request to fund release, note: transaction fee will be applied.</div>}
-
-                        {(status == ORDER_STATUS_NEW ||
-                            status == ORDER_STATUS_DEPOSITED && principal.toString() == order.seller.toString() ||
-                            status == ORDER_STATUS_DELIVERED && principal.toString() == order.buyer.toString()) && (
-                            <label className="inline-flex items-center gap-2 text-sm text-slate-700">
-                                <input type="checkbox" onChange={handleChange} />
-                                YES, I confirmed
-                            </label>
-                        )}
-                    </>
-                )}
-
-                <div className="flex flex-wrap gap-2">
-                    {!isFreeOrder && (
-                        <>
-                            {status == ORDER_STATUS_NEW && principal.toString() == order.buyer.toString() && <button type="button" disabled={!confirmed} onClick={deposit} className="rounded-md bg-cyan-600 px-3 py-2 text-sm font-semibold text-white transition hover:bg-cyan-700 disabled:cursor-not-allowed disabled:bg-slate-300">Deposit</button>}
-                            {status == ORDER_STATUS_DEPOSITED && principal.toString() == order.seller.toString() && <button type="button" disabled={!confirmed} onClick={deliver} className="rounded-md bg-cyan-600 px-3 py-2 text-sm font-semibold text-white transition hover:bg-cyan-700 disabled:cursor-not-allowed disabled:bg-slate-300">Deliver</button>}
-                            {status == ORDER_STATUS_DELIVERED && principal.toString() == order.buyer.toString() && <button type="button" disabled={!confirmed} onClick={receive} className="rounded-md bg-cyan-600 px-3 py-2 text-sm font-semibold text-white transition hover:bg-cyan-700 disabled:cursor-not-allowed disabled:bg-slate-300">Receive</button>}
-                            {status == ORDER_STATUS_CANCELED && principal.toString() == order.buyer.toString() && <button type="button" className="rounded-md bg-cyan-600 px-3 py-2 text-sm font-semibold text-white">Request to refund</button>}
-                            {status == ORDER_STATUS_RECEIVED && principal.toString() == order.seller.toString() && <button type="button" onClick={release} className="rounded-md bg-cyan-600 px-3 py-2 text-sm font-semibold text-white transition hover:bg-cyan-700">Request to release fund</button>}
-                            {status == ORDER_STATUS_NEW && <button type="button" disabled={!confirmed} onClick={cancelOrder} className="rounded-md border border-rose-500 px-3 py-2 text-sm font-semibold text-rose-600 transition hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-50">Cancel</button>}
-                        </>
-                    )}
-
-                    {canCloseOrder && <button type="button" onClick={closeOrder} className="rounded-md border border-slate-500 px-3 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50">Close Order</button>}
-
-                    <CommentButton id={order.id} reload={loadOrder}/>
+                    <p className="mt-1 text-sm text-slate-500">Created {moment.unix(Number(order.createtime) / 1_000_000_000).format('YYYY-MM-DD HH:mm')}</p>
+                    {order.memo && <p className="mt-2 text-sm font-medium text-slate-700">{order.memo}</p>}
+                </div>
+                <div className="rounded-xl bg-slate-950 px-4 py-3 text-right text-white">
+                    <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">Order amount</div>
+                    <div className="mt-1 text-lg font-semibold">{amountLabel}</div>
                 </div>
             </div>
 
-            <Comments comments={comments}/>
+            <section className="grid gap-3 md:grid-cols-3">
+                <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+                    <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">Buyer</div>
+                    <div className="mt-2 text-sm text-slate-800"><PrincipalName principal={order.buyer} /> {isBuyer && <span className="text-xs text-cyan-700">(you)</span>}</div>
+                </div>
+                <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+                    <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">Seller</div>
+                    <div className="mt-2 text-sm text-slate-800"><PrincipalName principal={order.seller} /> {isSeller && <span className="text-xs text-cyan-700">(you)</span>}</div>
+                </div>
+                <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+                    <div className="flex items-center justify-between gap-2">
+                        <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">Escrow balance</div>
+                        {!isFreeOrder && (
+                            <button type="button" disabled={balanceLoading} onClick={() => void refreshBalance()} className="text-xs font-semibold text-cyan-700 hover:text-cyan-900 disabled:opacity-50">
+                                {balanceLoading ? 'Checking…' : 'Refresh'}
+                            </button>
+                        )}
+                    </div>
+                    <div className="mt-2 text-sm font-semibold text-slate-900">{isFreeOrder ? 'No funds required' : balanceLoading && balance === null ? 'Checking…' : balanceLabel}</div>
+                </div>
+            </section>
 
-            {status === ORDER_STATUS_RELEASED && !isFreeOrder && principal?.toString() === order.buyer.toString() && !reviewSubmitted && (
+            {!isFreeOrder && (
+                <section className="rounded-xl border border-slate-200 bg-white p-4">
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                        <div>
+                            <h3 className="text-sm font-semibold text-slate-900">Refund protection</h3>
+                            <p className="mt-1 max-w-2xl text-xs leading-5 text-slate-500">
+                                Cancel and refund are different actions. Canceling an eligible order automatically attempts to return its escrow balance to the buyer. A separate refund action is shown only when a balance still exists and the current role/status allows it.
+                            </p>
+                        </div>
+                        <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-600">Destination: buyer</span>
+                    </div>
+
+                    {balanceError && <div className="mt-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">{balanceError} Refresh the balance before attempting a refund.</div>}
+
+                    {status === ORDER_STATUS_CANCELED && !balanceLoading && balance === 0n && (
+                        <div className="mt-3 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs leading-5 text-emerald-800">
+                            No escrow balance remains. The cancel flow has already completed its refund path.
+                        </div>
+                    )}
+
+                    {status === ORDER_STATUS_REFUNDED && (
+                        <div className="mt-3 rounded-lg border border-orange-200 bg-orange-50 px-3 py-2 text-xs leading-5 text-orange-800">This order is already marked refunded. No additional refund action is available.</div>
+                    )}
+
+                    {refundMode === 'seller_refund' && !canCancel && hasEscrowBalance && (
+                        <div className="mt-3 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-rose-200 bg-rose-50 px-3 py-3">
+                            <div>
+                                <div className="text-sm font-semibold text-rose-900">Refund available</div>
+                                <div className="mt-0.5 text-xs text-rose-700">As seller, you can return the remaining escrow balance to the buyer before settlement.</div>
+                            </div>
+                            <button type="button" disabled={Boolean(busyAction)} onClick={() => setPendingAction('refund')} className="rounded-lg bg-rose-600 px-3 py-2 text-sm font-semibold text-white hover:bg-rose-700 disabled:opacity-50">Refund buyer</button>
+                        </div>
+                    )}
+
+                    {refundMode === 'buyer_recovery' && !canCancel && hasEscrowBalance && (
+                        <div className="mt-3 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-3">
+                            <div>
+                                <div className="text-sm font-semibold text-amber-900">Residual escrow balance detected</div>
+                                <div className="mt-0.5 text-xs text-amber-700">The order is canceled but funds still remain in escrow. You can retry recovery to the buyer account.</div>
+                            </div>
+                            <button type="button" disabled={Boolean(busyAction)} onClick={() => setPendingAction('refund')} className="rounded-lg bg-amber-600 px-3 py-2 text-sm font-semibold text-white hover:bg-amber-700 disabled:opacity-50">Recover balance</button>
+                        </div>
+                    )}
+                </section>
+            )}
+
+            <section>
+                <div className="mb-2 flex items-center justify-between gap-3">
+                    <p className="text-sm font-semibold text-slate-700">Order progress</p>
+                    <span className="text-xs font-medium capitalize text-slate-500">{status}</span>
+                </div>
+                {isFreeOrder ? (
+                    <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-800">
+                        <p className="font-semibold">Free item claim</p>
+                        <p className="mt-1 text-xs leading-5">{isSeller ? 'Go back to the item to set Hold, Sold, or Relist.' : 'Waiting for the seller to update the item status.'}</p>
+                    </div>
+                ) : status === ORDER_STATUS_CANCELED || status === ORDER_STATUS_REFUNDED ? (
+                    <div className={`rounded-xl border px-4 py-3 text-sm ${statusStyle}`}>
+                        <div className="font-semibold capitalize">{status}</div>
+                        <div className="mt-1 text-xs leading-5">{status === ORDER_STATUS_CANCELED ? 'The order was canceled. Any remaining escrow balance can only be recovered through the refund path above.' : 'The escrow refund path has been completed for this order.'}</div>
+                    </div>
+                ) : (
+                    <div className="grid grid-cols-2 gap-2 text-xs sm:grid-cols-5">
+                        {[
+                            { label: 'New', step: 1 },
+                            { label: 'Deposited', step: 2 },
+                            { label: 'Delivered', step: 3 },
+                            { label: 'Received', step: 4 },
+                            { label: 'Complete', step: 5 },
+                        ].map(step => (
+                            <div key={step.step} className={`rounded-lg px-3 py-2 text-center font-medium ${activeStep >= step.step ? 'bg-cyan-700 text-white' : 'bg-slate-100 text-slate-500'}`}>{step.label}</div>
+                        ))}
+                    </div>
+                )}
+            </section>
+
+            {!isFreeOrder && (
+                <section className="space-y-3">
+                    {status === ORDER_STATUS_NEW && isBuyer && <div className="rounded-xl border border-sky-200 bg-sky-50 px-3 py-2 text-sm text-sky-800">Deposit {amountLabel} to the escrow account, then confirm the deposit. Canceling at this stage automatically attempts to return any escrowed funds.</div>}
+                    {status === ORDER_STATUS_NEW && isSeller && <div className="rounded-xl border border-sky-200 bg-sky-50 px-3 py-2 text-sm text-sky-800">Waiting for the buyer to fund escrow.</div>}
+                    {status === ORDER_STATUS_DEPOSITED && isSeller && <div className="rounded-xl border border-sky-200 bg-sky-50 px-3 py-2 text-sm text-sky-800">Confirm delivery, or cancel the order to return the escrow balance to the buyer.</div>}
+                    {status === ORDER_STATUS_DEPOSITED && isBuyer && <div className="rounded-xl border border-sky-200 bg-sky-50 px-3 py-2 text-sm text-sky-800">Funds are secured in escrow. Waiting for the seller to deliver.</div>}
+                    {status === ORDER_STATUS_DELIVERED && isBuyer && <div className="rounded-xl border border-sky-200 bg-sky-50 px-3 py-2 text-sm text-sky-800">Confirm only after you received the item/service. This moves the order to Received; the seller can then release or refund the escrowed funds.</div>}
+                    {status === ORDER_STATUS_RECEIVED && isSeller && <div className="rounded-xl border border-sky-200 bg-sky-50 px-3 py-2 text-sm text-sky-800">The buyer confirmed receipt. You may release funds to yourself or refund the remaining escrow balance to the buyer.</div>}
+                    {status === ORDER_STATUS_RELEASED && <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-800">Funds have been released to the seller. The normal refund path is no longer available.</div>}
+                    {status === ORDER_STATUS_CLOSED && <div className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-700">This order is closed.</div>}
+
+                    {needsConfirm && (
+                        <label className="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700">
+                            <input type="checkbox" checked={confirmed} onChange={event => setConfirmed(event.target.checked)} />
+                            I reviewed the order state and confirm this action.
+                        </label>
+                    )}
+                </section>
+            )}
+
+            <div className="flex flex-wrap gap-2 border-t border-slate-100 pt-4">
+                {!isFreeOrder && status === ORDER_STATUS_NEW && isBuyer && (
+                    <button type="button" disabled={!confirmed || Boolean(busyAction)} onClick={() => void deposit()} className="rounded-lg bg-cyan-700 px-3 py-2 text-sm font-semibold text-white hover:bg-cyan-800 disabled:cursor-not-allowed disabled:bg-slate-300">{busyAction === 'deposit' ? 'Confirming…' : 'Confirm deposit'}</button>
+                )}
+                {!isFreeOrder && status === ORDER_STATUS_DEPOSITED && isSeller && (
+                    <button type="button" disabled={!confirmed || Boolean(busyAction)} onClick={() => void deliver()} className="rounded-lg bg-cyan-700 px-3 py-2 text-sm font-semibold text-white hover:bg-cyan-800 disabled:cursor-not-allowed disabled:bg-slate-300">{busyAction === 'deliver' ? 'Confirming…' : 'Confirm delivery'}</button>
+                )}
+                {!isFreeOrder && status === ORDER_STATUS_DELIVERED && isBuyer && (
+                    <button type="button" disabled={!confirmed || Boolean(busyAction)} onClick={() => void receive()} className="rounded-lg bg-cyan-700 px-3 py-2 text-sm font-semibold text-white hover:bg-cyan-800 disabled:cursor-not-allowed disabled:bg-slate-300">{busyAction === 'receive' ? 'Confirming…' : 'Confirm received'}</button>
+                )}
+                {!isFreeOrder && status === ORDER_STATUS_RECEIVED && isSeller && (
+                    <button type="button" disabled={Boolean(busyAction)} onClick={() => setPendingAction('release')} className="rounded-lg bg-cyan-700 px-3 py-2 text-sm font-semibold text-white hover:bg-cyan-800 disabled:opacity-50">Release funds</button>
+                )}
+                {canCancel && (
+                    <button type="button" disabled={Boolean(busyAction)} onClick={() => setPendingAction('cancel')} className="rounded-lg border border-rose-400 px-3 py-2 text-sm font-semibold text-rose-700 hover:bg-rose-50 disabled:opacity-50">
+                        {status === ORDER_STATUS_DEPOSITED ? 'Cancel & refund buyer' : 'Cancel order'}
+                    </button>
+                )}
+                {canClose && (
+                    <button type="button" disabled={Boolean(busyAction)} onClick={() => setPendingAction('close')} className="rounded-lg border border-slate-300 px-3 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50 disabled:opacity-50">Close order</button>
+                )}
+                <CommentButton id={order.id} reload={() => void refreshOrder()} />
+            </div>
+
+            {!isFreeOrder && (
+                <details className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-600">
+                    <summary className="cursor-pointer font-semibold text-slate-700">Escrow account details</summary>
+                    <div className="mt-2 break-all font-mono">{order.account.id}</div>
+                    <div className="mt-1 text-slate-500">Refunds and releases are executed by the escrow canister. Applicable ledger/network fees are deducted according to the canister logic.</div>
+                </details>
+            )}
+
+            <Comments comments={comments} />
+
+            {status === ORDER_STATUS_RELEASED && !isFreeOrder && isBuyer && !reviewSubmitted && (
                 <ReviewForm orderId={order.id} onSubmitted={() => setReviewSubmitted(true)} />
             )}
-        </div>
 
-    )
+            {dialog && (
+                <ConfirmAction
+                    open={Boolean(pendingAction)}
+                    title={dialog.title}
+                    description={dialog.description}
+                    confirmLabel={dialog.confirmLabel}
+                    danger={dialog.danger}
+                    busy={Boolean(busyAction)}
+                    onCancel={() => !busyAction && setPendingAction(null)}
+                    onConfirm={() => void dialog.run()}
+                />
+            )}
+        </div>
+    );
 }

--- a/frontend/components/orders/OrderListItem.tsx
+++ b/frontend/components/orders/OrderListItem.tsx
@@ -6,14 +6,22 @@ import { useEscrow, useGlobalContext } from '../Store';
 import OrderDetail from './OrderDetail';
 import Comments from './CommentList';
 import {
-    ORDER_STATUS_NEW,
-    ORDER_STATUS_DEPOSITED,
-    ORDER_STATUS_DELIVERED,
-    ORDER_STATUS_RECEIVED,
-    ORDER_STATUS_RELEASED,
-    ORDER_STATUS_CLOSED,
     ORDER_STATUS_CANCELED,
+    ORDER_STATUS_CLOSED,
+    ORDER_STATUS_DELIVERED,
+    ORDER_STATUS_DEPOSITED,
+    ORDER_STATUS_NEW,
+    ORDER_STATUS_RECEIVED,
+    ORDER_STATUS_REFUNDED,
+    ORDER_STATUS_RELEASED,
 } from '../../lib/constants';
+import {
+    canCancelOrder,
+    canCloseOrder,
+    getOrderStatus,
+    needsProgressConfirmation,
+    refundModeForOrder,
+} from '../../lib/orderPolicy';
 import { currencyBase, currencySymbol } from '../../lib/currencyUtils';
 
 const STATUS_COLORS: Record<string, string> = {
@@ -27,12 +35,23 @@ const STATUS_COLORS: Record<string, string> = {
     refunded: 'bg-orange-50 text-orange-700 border-orange-300',
 };
 
-export default (props) => {
+function resultError(result: any): string {
+    if (!result || result.err === undefined) return 'Action failed';
+    if (typeof result.err === 'string') return result.err;
+    try {
+        return JSON.stringify(result.err, (_, value) => typeof value === 'bigint' ? value.toString() : value);
+    } catch {
+        return String(result.err);
+    }
+}
+
+export default function OrderListItem(props) {
     const escrow = useEscrow();
     const { state: { principal } } = useGlobalContext();
 
     const [openOrder, setOpenOrder] = React.useState(false);
-    const [status, setStatus] = React.useState<string>(Object.getOwnPropertyNames(props.order.status)[0]);
+    const [detailOrder, setDetailOrder] = React.useState(props.order);
+    const [status, setStatus] = React.useState<string>(getOrderStatus(props.order.status));
     const [confirmed, setConfirmed] = React.useState(false);
     const [busy, setBusy] = React.useState(false);
     const [showComment, setShowComment] = React.useState(false);
@@ -41,32 +60,74 @@ export default (props) => {
 
     const currency = currencySymbol(props.order.currency);
     const es = currencyBase(props.order.currency);
-    const amount = parseInt(props.order.amount) / es;
-    const isFreeOrder = amount === 0;
+    const amount = Number(props.order.amount) / es;
+    const isFreeOrder = BigInt(props.order.amount ?? 0) === 0n;
     const isBuyer = principal?.toString() === props.order.buyer.toString();
     const isSeller = principal?.toString() === props.order.seller.toString();
-    const isTerminal = status === ORDER_STATUS_CLOSED || status === ORDER_STATUS_CANCELED || status === 'refunded';
+    const isTerminal = status === ORDER_STATUS_CLOSED || status === ORDER_STATUS_CANCELED || status === ORDER_STATUS_REFUNDED;
+    const needsConfirm = !isFreeOrder && needsProgressConfirmation(status, isBuyer, isSeller);
+    const canCancel = !isFreeOrder && canCancelOrder(status, isBuyer, isSeller);
+    const refundMode = !isFreeOrder ? refundModeForOrder(status, isBuyer, isSeller) : null;
+    const canClose = canCloseOrder(status, isSeller);
 
-    const needsConfirm =
-        (status === ORDER_STATUS_NEW && isBuyer) ||
-        (status === ORDER_STATUS_DEPOSITED && isSeller) ||
-        (status === ORDER_STATUS_DELIVERED && isBuyer);
+    React.useEffect(() => {
+        setStatus(getOrderStatus(props.order.status));
+        setComments(props.order.comments ?? []);
+        setDetailOrder(props.order);
+        setConfirmed(false);
+    }, [props.order]);
 
-    async function act(fn: () => Promise<any>, nextStatus: string) {
+    function applyFreshOrder(fresh: any) {
+        if (!fresh) return;
+        setDetailOrder(fresh);
+        setStatus(getOrderStatus(fresh.status));
+        setComments(fresh.comments ?? []);
+        setConfirmed(false);
+    }
+
+    async function refreshSnapshot() {
+        try {
+            const result = await escrow.getOrder(props.order.id);
+            const fresh = result?.[0];
+            if (fresh) applyFreshOrder(fresh);
+            return fresh ?? null;
+        } catch {
+            return null;
+        }
+    }
+
+    async function act(
+        fn: () => Promise<any>,
+        nextStatus: string,
+        successMessage = 'Status updated',
+        confirmMessage?: string,
+    ) {
+        if (confirmMessage && !window.confirm(confirmMessage)) return;
         setBusy(true);
         try {
             const res = await fn();
-            if (res['ok'] !== undefined) {
-                toast.success('Status updated');
+            if (res && Object.prototype.hasOwnProperty.call(res, 'ok')) {
+                toast.success(successMessage);
                 setStatus(nextStatus);
                 setConfirmed(false);
+                await refreshSnapshot();
             } else {
-                toast.error(res['err'] ?? 'Action failed');
+                toast.error(resultError(res));
             }
-        } catch {
-            toast.error('Action failed');
+        } catch (error: any) {
+            toast.error(error?.message ?? 'Action failed');
         } finally {
             setBusy(false);
+        }
+    }
+
+    async function openDetails() {
+        setBusy(true);
+        try {
+            await refreshSnapshot();
+        } finally {
+            setBusy(false);
+            setOpenOrder(true);
         }
     }
 
@@ -76,16 +137,18 @@ export default (props) => {
         setBusy(true);
         try {
             const res = await escrow.comment(props.order.id, text);
-            if (res['ok'] !== undefined) {
+            if (res && Object.prototype.hasOwnProperty.call(res, 'ok')) {
                 toast.success('Comment posted');
-                setComments(prev => [...prev, { user: principal, comment: text, ctime: BigInt(Date.now()) * BigInt(1_000_000) }]);
+                const optimistic = { user: principal, comment: text, ctime: BigInt(Date.now()) * 1_000_000n };
+                setComments(prev => [...prev, optimistic]);
                 setCommentText('');
                 setShowComment(false);
+                await refreshSnapshot();
             } else {
-                toast.error(res['err'] ?? 'Failed to post comment');
+                toast.error(resultError(res));
             }
-        } catch {
-            toast.error('Failed to post comment');
+        } catch (error: any) {
+            toast.error(error?.message ?? 'Failed to post comment');
         } finally {
             setBusy(false);
         }
@@ -96,147 +159,140 @@ export default (props) => {
     return (
         <>
             <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-                {/* Header */}
                 <div className="mb-3 flex items-start justify-between gap-3">
                     <div className="min-w-0">
                         <div className="flex items-center gap-2">
-                            <button
-                                type="button"
-                                onClick={() => setOpenOrder(true)}
-                                className="text-sm font-semibold text-orange-700 transition hover:text-orange-800 hover:underline"
-                            >
-                                #{parseInt(props.order.id)}
+                            <button type="button" disabled={busy} onClick={() => void openDetails()} className="text-sm font-semibold text-orange-700 transition hover:text-orange-800 hover:underline disabled:opacity-50">
+                                #{String(props.order.id)}
                             </button>
-                            <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide ${statusColor}`}>
-                                {status}
-                            </span>
+                            <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide ${statusColor}`}>{status}</span>
                         </div>
-                        <p className="mt-1 text-base font-semibold text-slate-900 truncate">{props.order.memo}</p>
+                        <p className="mt-1 truncate text-base font-semibold text-slate-900">{props.order.memo}</p>
                     </div>
                     <span className="flex-shrink-0 rounded-full border border-teal-600/50 bg-teal-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-teal-700">
                         {isFreeOrder ? 'FREE' : `${amount} ${currency}`}
                     </span>
                 </div>
 
-                {/* Meta */}
                 <p className="mb-3 text-xs text-slate-500">
-                    {isBuyer ? 'You are buyer' : 'You are seller'} · {moment.unix(parseInt(props.order.createtime) / 1_000_000_000).format('YYYY-MM-DD HH:mm')}
+                    {isBuyer ? 'You are buyer' : isSeller ? 'You are seller' : 'Participant'} · {moment.unix(Number(props.order.createtime) / 1_000_000_000).format('YYYY-MM-DD HH:mm')}
                 </p>
 
-                {/* Hint */}
-                {!isFreeOrder && !isTerminal && (() => {
-                    if (status === ORDER_STATUS_NEW && isBuyer) return <p className="mb-2 rounded-md border border-sky-200 bg-sky-50 px-3 py-2 text-xs text-sky-800">Deposit {amount} {currency} to escrow account to proceed.</p>;
-                    if (status === ORDER_STATUS_NEW && isSeller) return <p className="mb-2 rounded-md border border-sky-200 bg-sky-50 px-3 py-2 text-xs text-sky-800">Waiting for buyer to deposit funds.</p>;
-                    if (status === ORDER_STATUS_DEPOSITED && isSeller) return <p className="mb-2 rounded-md border border-sky-200 bg-sky-50 px-3 py-2 text-xs text-sky-800">Confirm delivery of "{props.order.memo}" to buyer.</p>;
-                    if (status === ORDER_STATUS_DEPOSITED && isBuyer) return <p className="mb-2 rounded-md border border-sky-200 bg-sky-50 px-3 py-2 text-xs text-sky-800">Waiting for seller to deliver.</p>;
-                    if (status === ORDER_STATUS_DELIVERED && isBuyer) return <p className="mb-2 rounded-md border border-sky-200 bg-sky-50 px-3 py-2 text-xs text-sky-800">Confirm receipt — this releases funds to the seller.</p>;
-                    if (status === ORDER_STATUS_RECEIVED && isSeller) return <p className="mb-2 rounded-md border border-sky-200 bg-sky-50 px-3 py-2 text-xs text-sky-800">Request fund release (transaction fee applies).</p>;
+                {!isFreeOrder && (() => {
+                    if (status === ORDER_STATUS_NEW && isBuyer) return <p className="mb-2 rounded-md border border-sky-200 bg-sky-50 px-3 py-2 text-xs text-sky-800">Fund escrow, then confirm the deposit. Canceling automatically attempts to return escrowed funds.</p>;
+                    if (status === ORDER_STATUS_NEW && isSeller) return <p className="mb-2 rounded-md border border-sky-200 bg-sky-50 px-3 py-2 text-xs text-sky-800">Waiting for buyer to fund escrow.</p>;
+                    if (status === ORDER_STATUS_DEPOSITED && isSeller) return <p className="mb-2 rounded-md border border-sky-200 bg-sky-50 px-3 py-2 text-xs text-sky-800">Deliver the order, or cancel and refund the buyer.</p>;
+                    if (status === ORDER_STATUS_DEPOSITED && isBuyer) return <p className="mb-2 rounded-md border border-sky-200 bg-sky-50 px-3 py-2 text-xs text-sky-800">Funds are secured. Waiting for seller delivery.</p>;
+                    if (status === ORDER_STATUS_DELIVERED && isBuyer) return <p className="mb-2 rounded-md border border-sky-200 bg-sky-50 px-3 py-2 text-xs text-sky-800">Confirm receipt only after delivery. Seller can release funds after confirmation.</p>;
+                    if (status === ORDER_STATUS_RECEIVED && isSeller) return <p className="mb-2 rounded-md border border-sky-200 bg-sky-50 px-3 py-2 text-xs text-sky-800">Buyer confirmed receipt. Release funds, or review refund options before settlement.</p>;
+                    if (status === ORDER_STATUS_CANCELED) return <p className="mb-2 rounded-md border border-rose-200 bg-rose-50 px-3 py-2 text-xs text-rose-800">Canceled. The cancel flow already attempts an automatic buyer refund; open details only if you need to verify/recover a remaining escrow balance.</p>;
+                    if (status === ORDER_STATUS_REFUNDED) return <p className="mb-2 rounded-md border border-orange-200 bg-orange-50 px-3 py-2 text-xs text-orange-800">Refund completed.</p>;
+                    if (status === ORDER_STATUS_RELEASED) return <p className="mb-2 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-800">Funds released to seller.</p>;
                     return null;
                 })()}
 
-                {/* Confirm checkbox */}
-                {needsConfirm && !isFreeOrder && (
+                {needsConfirm && (
                     <label className="mb-2 inline-flex items-center gap-2 text-sm text-slate-700 select-none">
-                        <input type="checkbox" checked={confirmed} onChange={e => setConfirmed(e.target.checked)} />
-                        YES, I confirmed
+                        <input type="checkbox" checked={confirmed} onChange={event => setConfirmed(event.target.checked)} />
+                        I confirm this step
                     </label>
                 )}
 
-                {/* Actions */}
                 {!isTerminal && (
                     <div className="flex flex-wrap gap-2">
                         {!isFreeOrder && status === ORDER_STATUS_NEW && isBuyer && (
-                            <button disabled={!confirmed || busy} onClick={() => act(() => escrow.deposit(props.order.id), ORDER_STATUS_DEPOSITED)}
+                            <button disabled={!confirmed || busy} onClick={() => void act(() => escrow.deposit(props.order.id), ORDER_STATUS_DEPOSITED, 'Deposit confirmed')}
                                 className="rounded-md bg-cyan-600 px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-cyan-700 disabled:cursor-not-allowed disabled:bg-slate-300">
-                                Deposit
+                                Confirm deposit
                             </button>
                         )}
                         {!isFreeOrder && status === ORDER_STATUS_DEPOSITED && isSeller && (
-                            <button disabled={!confirmed || busy} onClick={() => act(() => escrow.deliver(props.order.id), ORDER_STATUS_DELIVERED)}
+                            <button disabled={!confirmed || busy} onClick={() => void act(() => escrow.deliver(props.order.id), ORDER_STATUS_DELIVERED, 'Delivery confirmed')}
                                 className="rounded-md bg-cyan-600 px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-cyan-700 disabled:cursor-not-allowed disabled:bg-slate-300">
-                                Deliver
+                                Confirm delivery
                             </button>
                         )}
                         {!isFreeOrder && status === ORDER_STATUS_DELIVERED && isBuyer && (
-                            <button disabled={!confirmed || busy} onClick={() => act(() => escrow.receive(props.order.id), ORDER_STATUS_RECEIVED)}
+                            <button disabled={!confirmed || busy} onClick={() => void act(() => escrow.receive(props.order.id), ORDER_STATUS_RECEIVED, 'Receipt confirmed')}
                                 className="rounded-md bg-cyan-600 px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-cyan-700 disabled:cursor-not-allowed disabled:bg-slate-300">
-                                Receive
+                                Confirm received
                             </button>
                         )}
                         {!isFreeOrder && status === ORDER_STATUS_RECEIVED && isSeller && (
-                            <button disabled={busy} onClick={() => act(() => escrow.release(props.order.id), ORDER_STATUS_RELEASED)}
+                            <button disabled={busy} onClick={() => void act(
+                                () => escrow.release(props.order.id),
+                                ORDER_STATUS_RELEASED,
+                                'Funds released to seller',
+                                'Release escrow funds to the seller? This is irreversible and removes the normal refund path.',
+                            )}
                                 className="rounded-md bg-cyan-600 px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-cyan-700 disabled:cursor-not-allowed disabled:bg-slate-300">
-                                Release Fund
+                                Release funds
                             </button>
                         )}
-                        {!isFreeOrder && status === ORDER_STATUS_NEW && (
-                            <button disabled={busy} onClick={() => act(() => escrow.cancel(props.order.id), ORDER_STATUS_CANCELED)}
+                        {canCancel && (
+                            <button disabled={busy} onClick={() => void act(
+                                () => escrow.cancel(props.order.id),
+                                ORDER_STATUS_CANCELED,
+                                'Order canceled; escrow refund was attempted automatically',
+                                status === ORDER_STATUS_DEPOSITED
+                                    ? 'Cancel this funded order and return the refundable escrow balance to the buyer?'
+                                    : 'Cancel this order? If escrow already holds funds, the canister will attempt to return them to the buyer.',
+                            )}
                                 className="rounded-md border border-rose-400 px-3 py-1.5 text-sm font-semibold text-rose-600 transition hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-50">
-                                Cancel
+                                {status === ORDER_STATUS_DEPOSITED ? 'Cancel & refund' : 'Cancel'}
                             </button>
                         )}
-                        {isSeller && (
-                            <button disabled={busy} onClick={() => act(() => escrow.close(props.order.id), ORDER_STATUS_CLOSED)}
+                        {refundMode && !canCancel && !isFreeOrder && (
+                            <button type="button" disabled={busy} onClick={() => void openDetails()} className="rounded-md border border-amber-400 px-3 py-1.5 text-sm font-semibold text-amber-700 transition hover:bg-amber-50 disabled:opacity-50">
+                                Refund options
+                            </button>
+                        )}
+                        {canClose && (
+                            <button disabled={busy} onClick={() => void act(
+                                () => escrow.close(props.order.id),
+                                ORDER_STATUS_CLOSED,
+                                'Order closed',
+                                'Close this order? Review any remaining escrow balance in Details before continuing.',
+                            )}
                                 className="rounded-md border border-slate-400 px-3 py-1.5 text-sm font-semibold text-slate-600 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50">
                                 Close
                             </button>
                         )}
-                        <button type="button" onClick={() => setShowComment(v => !v)}
-                            className="rounded-md border border-slate-300 px-3 py-1.5 text-sm font-semibold text-slate-600 transition hover:bg-slate-50">
-                            {showComment ? 'Cancel' : 'Comment'}
+                        <button type="button" onClick={() => setShowComment(value => !value)} className="rounded-md border border-slate-300 px-3 py-1.5 text-sm font-semibold text-slate-600 transition hover:bg-slate-50">
+                            {showComment ? 'Cancel comment' : 'Comment'}
                         </button>
                     </div>
                 )}
 
                 {isTerminal && (
                     <div className="flex flex-wrap gap-2">
-                        <button type="button" onClick={() => setOpenOrder(true)}
-                            className="rounded-md border border-slate-300 px-3 py-1.5 text-sm font-semibold text-slate-600 transition hover:bg-slate-50">
-                            View Details
+                        <button type="button" disabled={busy} onClick={() => void openDetails()} className="rounded-md border border-slate-300 px-3 py-1.5 text-sm font-semibold text-slate-600 transition hover:bg-slate-50 disabled:opacity-50">
+                            {status === ORDER_STATUS_CANCELED && refundMode ? 'Review refund' : 'View details'}
                         </button>
-                        <button type="button" onClick={() => setShowComment(v => !v)}
-                            className="rounded-md border border-slate-300 px-3 py-1.5 text-sm font-semibold text-slate-600 transition hover:bg-slate-50">
-                            {showComment ? 'Cancel' : 'Comment'}
+                        <button type="button" onClick={() => setShowComment(value => !value)} className="rounded-md border border-slate-300 px-3 py-1.5 text-sm font-semibold text-slate-600 transition hover:bg-slate-50">
+                            {showComment ? 'Cancel comment' : 'Comment'}
                         </button>
                     </div>
                 )}
 
                 {showComment && (
                     <div className="mt-3">
-                        <textarea
-                            value={commentText}
-                            onChange={e => setCommentText(e.target.value)}
-                            rows={2}
-                            placeholder="Write a comment…"
-                            className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-cyan-500"
-                        />
+                        <textarea value={commentText} onChange={event => setCommentText(event.target.value)} rows={2} placeholder="Write a comment…" className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-cyan-500" />
                         <div className="mt-1 flex justify-end gap-2">
-                            <button type="button" onClick={() => { setShowComment(false); setCommentText(''); }}
-                                className="rounded-md border border-slate-300 px-3 py-1.5 text-sm font-semibold text-slate-600 transition hover:bg-slate-50">
-                                Cancel
-                            </button>
-                            <button type="button" disabled={!commentText.trim() || busy} onClick={submitComment}
-                                className="rounded-md bg-cyan-600 px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-cyan-700 disabled:cursor-not-allowed disabled:bg-slate-300">
-                                Post
-                            </button>
+                            <button type="button" onClick={() => { setShowComment(false); setCommentText(''); }} className="rounded-md border border-slate-300 px-3 py-1.5 text-sm font-semibold text-slate-600 transition hover:bg-slate-50">Cancel</button>
+                            <button type="button" disabled={!commentText.trim() || busy} onClick={() => void submitComment()} className="rounded-md bg-cyan-600 px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-cyan-700 disabled:cursor-not-allowed disabled:bg-slate-300">{busy ? 'Posting…' : 'Post'}</button>
                         </div>
                     </div>
                 )}
 
-                {comments.length > 0 && (
-                    <Comments comments={comments} />
-                )}
+                {comments.length > 0 && <Comments comments={comments} />}
             </div>
 
             {openOrder && (
                 <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" onClick={() => setOpenOrder(false)}>
-                    <div className="relative max-h-[90vh] w-full max-w-3xl overflow-auto rounded-lg bg-white p-4" onClick={(e) => e.stopPropagation()}>
-                        <button type="button" onClick={() => setOpenOrder(false)}
-                            className="absolute right-3 top-3 h-8 w-8 rounded-full text-slate-500 transition hover:bg-slate-100">
-                            ✕
-                        </button>
-                        <h3 className="mb-4 text-lg font-semibold text-slate-900">Order: {props.order.memo}</h3>
-                        <OrderDetail order={props.order} />
+                    <div className="relative max-h-[90vh] w-full max-w-3xl overflow-auto rounded-2xl bg-white p-4 shadow-2xl" onClick={event => event.stopPropagation()}>
+                        <button type="button" onClick={() => setOpenOrder(false)} className="absolute right-3 top-3 z-10 h-8 w-8 rounded-full text-slate-500 transition hover:bg-slate-100">✕</button>
+                        <OrderDetail order={detailOrder} onChanged={applyFreshOrder} />
                     </div>
                 </div>
             )}

--- a/frontend/lib/orderPolicy.ts
+++ b/frontend/lib/orderPolicy.ts
@@ -1,0 +1,66 @@
+import {
+    ORDER_STATUS_CANCELED,
+    ORDER_STATUS_CLOSED,
+    ORDER_STATUS_DEPOSITED,
+    ORDER_STATUS_DELIVERED,
+    ORDER_STATUS_NEW,
+    ORDER_STATUS_RECEIVED,
+    ORDER_STATUS_REFUNDED,
+    ORDER_STATUS_RELEASED,
+} from './constants';
+
+export type RefundMode = 'seller_refund' | 'buyer_recovery' | null;
+
+export function getOrderStatus(statusVariant: Record<string, unknown> | null | undefined): string {
+    return statusVariant ? Object.keys(statusVariant)[0] ?? '' : '';
+}
+
+export function isFinalOrderStatus(status: string): boolean {
+    return status === ORDER_STATUS_CLOSED || status === ORDER_STATUS_REFUNDED;
+}
+
+export function isCanceledOrderStatus(status: string): boolean {
+    return status === ORDER_STATUS_CANCELED;
+}
+
+export function canCancelOrder(status: string, isBuyer: boolean, isSeller: boolean): boolean {
+    return (status === ORDER_STATUS_NEW && isBuyer)
+        || (status === ORDER_STATUS_DEPOSITED && isSeller);
+}
+
+export function refundModeForOrder(status: string, isBuyer: boolean, isSeller: boolean): RefundMode {
+    if (isSeller
+        && status !== ORDER_STATUS_RELEASED
+        && status !== ORDER_STATUS_REFUNDED
+        && status !== ORDER_STATUS_CLOSED) {
+        return 'seller_refund';
+    }
+
+    if (isBuyer && (status === ORDER_STATUS_NEW || status === ORDER_STATUS_CANCELED)) {
+        return 'buyer_recovery';
+    }
+
+    return null;
+}
+
+export function canCloseOrder(status: string, isSeller: boolean): boolean {
+    return isSeller
+        && status !== ORDER_STATUS_CLOSED
+        && status !== ORDER_STATUS_CANCELED
+        && status !== ORDER_STATUS_REFUNDED;
+}
+
+export function needsProgressConfirmation(status: string, isBuyer: boolean, isSeller: boolean): boolean {
+    return (status === ORDER_STATUS_NEW && isBuyer)
+        || (status === ORDER_STATUS_DEPOSITED && isSeller)
+        || (status === ORDER_STATUS_DELIVERED && isBuyer);
+}
+
+export function orderProgressStep(status: string): number {
+    if (status === ORDER_STATUS_NEW) return 1;
+    if (status === ORDER_STATUS_DEPOSITED) return 2;
+    if (status === ORDER_STATUS_DELIVERED) return 3;
+    if (status === ORDER_STATUS_RECEIVED) return 4;
+    if (status === ORDER_STATUS_RELEASED || status === ORDER_STATUS_CLOSED) return 5;
+    return 0;
+}

--- a/frontend/lib/orderPolicy.ts
+++ b/frontend/lib/orderPolicy.ts
@@ -15,14 +15,6 @@ export function getOrderStatus(statusVariant: Record<string, unknown> | null | u
     return statusVariant ? Object.keys(statusVariant)[0] ?? '' : '';
 }
 
-export function isFinalOrderStatus(status: string): boolean {
-    return status === ORDER_STATUS_CLOSED || status === ORDER_STATUS_REFUNDED;
-}
-
-export function isCanceledOrderStatus(status: string): boolean {
-    return status === ORDER_STATUS_CANCELED;
-}
-
 export function canCancelOrder(status: string, isBuyer: boolean, isSeller: boolean): boolean {
     return (status === ORDER_STATUS_NEW && isBuyer)
         || (status === ORDER_STATUS_DEPOSITED && isSeller);
@@ -43,8 +35,8 @@ export function refundModeForOrder(status: string, isBuyer: boolean, isSeller: b
     return null;
 }
 
-export function canCloseOrder(status: string, isSeller: boolean): boolean {
-    return isSeller
+export function canCloseOrder(status: string, isBuyer: boolean, isSeller: boolean): boolean {
+    return (isBuyer || isSeller)
         && status !== ORDER_STATUS_CLOSED
         && status !== ORDER_STATUS_CANCELED
         && status !== ORDER_STATUS_REFUNDED;


### PR DESCRIPTION
## What changed

- Reworks order refund UX so `Cancel` and `Refund` have distinct meanings.
- Makes cancel copy explicit that eligible escrow funds are automatically returned to the buyer by the canister.
- Connects the previously non-functional refund path in Order Detail and only exposes recovery/refund actions when a live escrow balance remains.
- Uses `getOrderBalance(orderId)` for the balance shown in refund decisions, including ICRC-1 subaccount-backed orders.
- Adds a shared order-policy helper so Order Detail and Order List use the same role/status rules for cancel, refund, close, and confirmation requirements.
- Adds final confirmation for refund, cancel-with-funds, release, and close actions.
- Refreshes the authoritative order snapshot after mutations so list/detail status and comments do not drift.
- Adds seller `deposited -> cancel & refund buyer` UI, matching the existing canister transition.
- Removes misleading copy that implied `receive` immediately releases funds; release remains a separate seller action.

## Refund behavior represented by the UI

- Buyer + `new`: cancel is the normal path; cancellation attempts to return any escrowed funds automatically.
- Seller + `deposited`: cancel becomes **Cancel & refund buyer**.
- Seller before settlement: a standalone refund option is available from Order Detail only when escrow still contains funds.
- Buyer + `canceled`: a recovery action is shown only if a residual escrow balance still exists.
- `released`, `refunded`, and `closed`: normal refund controls are not shown.

## Review focus

- role/status action policy vs current escrow canister permissions
- `getOrderBalance` result handling for ICP / ICET / ICRC-1
- stale order state after quick actions and detail-modal actions
- mobile behavior of refund confirmation and balance panels
