### PR TITLE
UX phase 1–2: guided escrow and marketplace flows

### DIFF
--- a/frontend/.ic-assets.json5
+++ b/frontend/.ic-assets.json5
@@ -18,5 +18,9 @@
       "Content-Type": "application/json"
     },
     "ignore": false
+  },
+  {
+    "match": "**/*",
+    "enable_aliasing": true
   }
 ]

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -8,7 +8,7 @@ import {
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 
-import Store, { useGlobalContext } from "./components/Store";
+import Store from "./components/Store";
 import Header from './header';
 import { ProfilePage } from "./pages/Profile"
 import Item from "./pages/Item";
@@ -55,11 +55,6 @@ declare global {
   }
 }
 
-const RequireAuth = ({ children }: { children: React.ReactElement }) => {
-  const { state: { isAuthed } } = useGlobalContext();
-  return isAuthed ? children : <Navigate to="/market" replace />;
-};
-
 const AppRoutes = () => (
   <div className="fade-in relative min-h-screen w-full overflow-x-hidden px-4 pb-28 pt-24 sm:px-6 md:pb-14 lg:px-10">
     <div className="pointer-events-none absolute -left-24 top-16 h-72 w-72 rounded-full bg-orange-200/45 blur-3xl" />
@@ -76,30 +71,9 @@ const AppRoutes = () => (
         <Route path="/" element={<Navigate to="/market" replace />} />
         <Route path="/market" element={<OfferList />} />
         <Route path="/free" element={<OfferList freeOnly />} />
-        <Route
-          path="/orders"
-          element={(
-            <RequireAuth>
-              <OrderList />
-            </RequireAuth>
-          )}
-        />
-        <Route
-          path="/items"
-          element={(
-            <RequireAuth>
-              <MyItems />
-            </RequireAuth>
-          )}
-        />
-        <Route
-          path="/profile"
-          element={(
-            <RequireAuth>
-              <ProfilePage />
-            </RequireAuth>
-          )}
-        />
+        <Route path="/orders" element={<OrderList />} />
+        <Route path="/items" element={<MyItems />} />
+        <Route path="/profile" element={<ProfilePage />} />
         <Route path="/item/:id" element={<Item />} />
         <Route path="/userid/:userId" element={<UserItems />} />
         <Route path="/giveaway/:id" element={<GiveAwayPage />} />

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,21 +1,23 @@
 import React from "react"
 import {
   BrowserRouter,
-  Routes,
+  Navigate,
   Route,
-
+  Routes,
 } from "react-router-dom";
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 
-import Store from "./components/Store";
+import Store, { useGlobalContext } from "./components/Store";
 import Header from './header';
-// import Navbar from "./components/Navbar";
 import { ProfilePage } from "./pages/Profile"
-import { Home } from "./pages/Home";
 import Item from "./pages/Item";
 import UserItems from "./pages/UserItems";
 import GiveAwayPage from "./pages/GiveAway";
+import OfferList from "./components/offers/OfferList";
+import OrderList from "./components/orders/OrderList";
+import MyItems from "./components/items/MyItems";
+
 declare global {
   interface Window {
     ic: {
@@ -53,34 +55,66 @@ declare global {
   }
 }
 
+const RequireAuth = ({ children }: { children: React.ReactElement }) => {
+  const { state: { isAuthed } } = useGlobalContext();
+  return isAuthed ? children : <Navigate to="/market" replace />;
+};
+
+const AppRoutes = () => (
+  <div className="fade-in relative min-h-screen w-full overflow-x-hidden px-4 pb-28 pt-24 sm:px-6 md:pb-14 lg:px-10">
+    <div className="pointer-events-none absolute -left-24 top-16 h-72 w-72 rounded-full bg-orange-200/45 blur-3xl" />
+    <div className="pointer-events-none absolute -right-24 top-10 h-80 w-80 rounded-full bg-teal-200/45 blur-3xl" />
+    <div className="pointer-events-none absolute bottom-0 left-1/2 h-64 w-[85%] -translate-x-1/2 rounded-[50%] bg-amber-100/40 blur-3xl" />
+    <div className="hero-ring pointer-events-none left-6 top-32 h-32 w-32" />
+    <div className="hero-ring pointer-events-none right-8 top-52 h-20 w-20" />
+
+    <Header />
+    <ToastContainer />
+
+    <main className="relative mx-auto w-full max-w-7xl">
+      <Routes>
+        <Route path="/" element={<Navigate to="/market" replace />} />
+        <Route path="/market" element={<OfferList />} />
+        <Route path="/free" element={<OfferList freeOnly />} />
+        <Route
+          path="/orders"
+          element={(
+            <RequireAuth>
+              <OrderList />
+            </RequireAuth>
+          )}
+        />
+        <Route
+          path="/items"
+          element={(
+            <RequireAuth>
+              <MyItems />
+            </RequireAuth>
+          )}
+        />
+        <Route
+          path="/profile"
+          element={(
+            <RequireAuth>
+              <ProfilePage />
+            </RequireAuth>
+          )}
+        />
+        <Route path="/item/:id" element={<Item />} />
+        <Route path="/userid/:userId" element={<UserItems />} />
+        <Route path="/giveaway/:id" element={<GiveAwayPage />} />
+        <Route path="*" element={<Navigate to="/market" replace />} />
+      </Routes>
+    </main>
+  </div>
+);
+
 export default () => {
   return (
     <BrowserRouter>
       <Store>
-        <div className="fade-in relative min-h-screen w-full overflow-x-hidden px-4 pb-14 pt-24 sm:px-6 lg:px-10">
-          <div className="pointer-events-none absolute -left-24 top-16 h-72 w-72 rounded-full bg-orange-200/45 blur-3xl" />
-          <div className="pointer-events-none absolute -right-24 top-10 h-80 w-80 rounded-full bg-teal-200/45 blur-3xl" />
-          <div className="pointer-events-none absolute bottom-0 left-1/2 h-64 w-[85%] -translate-x-1/2 rounded-[50%] bg-amber-100/40 blur-3xl" />
-          <div className="hero-ring pointer-events-none left-6 top-32 h-32 w-32" />
-          <div className="hero-ring pointer-events-none right-8 top-52 h-20 w-20" />
-
-          <Header />
-          <ToastContainer />
-
-          <main className="relative mx-auto w-full max-w-7xl">
-            <Routes>
-              <Route path="/profile" element={<ProfilePage />} />
-              <Route path="/item/:id" element={<Item />} />
-              <Route path="/userid/:userId" element={<UserItems />} />
-              <Route path="/giveaway/:id" element={<GiveAwayPage />} />
-              <Route path="/" element={<Home />} />
-            </Routes>
-          </main>
-        </div>
+        <AppRoutes />
       </Store>
     </BrowserRouter>
-
-
   )
 }
-

--- a/frontend/components/items/ItemList.tsx
+++ b/frontend/components/items/ItemList.tsx
@@ -6,26 +6,45 @@ import { currencyBase } from '../../lib/currencyUtils';
 import { getServiceId } from '../../api/escrow/serviceModels';
 import { ServiceInfo } from '../../api/escrow/serviceModels';
 
-
 interface ItemListProps {
     items: Item[];
     onItemClick?: (item: Item) => void;
-    defaultFilter?: string; // Optional default filter
+    defaultFilter?: string;
     freeOnly?: boolean;
     servicesById?: Record<string, ServiceInfo>;
+    searchTerm?: string;
+    onSearchTermChange?: (value: string) => void;
+    searching?: boolean;
+    remoteSearch?: boolean;
 }
 
-const ItemList: React.FC<ItemListProps> = ({ items, onItemClick, defaultFilter, freeOnly = false, servicesById = {} }) => {
+const ItemList: React.FC<ItemListProps> = ({
+    items,
+    onItemClick,
+    defaultFilter,
+    freeOnly = false,
+    servicesById = {},
+    searchTerm: controlledSearchTerm,
+    onSearchTermChange,
+    searching = false,
+    remoteSearch = false,
+}) => {
     const navigate = useNavigate();
     const initialFilter = defaultFilter || 'all';
     const [activeFilter, setActiveFilter] = React.useState(initialFilter);
-    const [searchTerm, setSearchTerm] = React.useState('');
+    const [localSearchTerm, setLocalSearchTerm] = React.useState('');
     const [sortBy, setSortBy] = React.useState('newest');
     const filters = ['all', 'free', 'nft', 'coin', 'service', 'merchandise', 'other'];
+    const searchTerm = controlledSearchTerm ?? localSearchTerm;
 
-    const availableItems = React.useMemo(() => {
-        return items.filter((item) => Object.getOwnPropertyNames(item.status)[0] === 'list');
-    }, [items]);
+    const setSearchTerm = (value: string) => {
+        if (onSearchTermChange) onSearchTermChange(value);
+        else setLocalSearchTerm(value);
+    };
+
+    const availableItems = React.useMemo(() =>
+        items.filter((item) => Object.getOwnPropertyNames(item.status)[0] === 'list'),
+    [items]);
 
     const getItemType = React.useCallback((item: Item) => {
         const serviceId = getServiceId(item.itype as any);
@@ -49,19 +68,17 @@ const ItemList: React.FC<ItemListProps> = ({ items, onItemClick, defaultFilter, 
             }
         }
         return counts;
-    }, [availableItems, filters, getItemType, toPriceNumber]);
+    }, [availableItems, getItemType, toPriceNumber]);
 
     const visibleItems = React.useMemo(() => {
         const normalizedSearch = searchTerm.trim().toLowerCase();
-
         const filtered = availableItems.filter((item) => {
             const type = getItemType(item);
             const matchesType = activeFilter === 'all'
                 || (activeFilter === 'free' && toPriceNumber(item) === 0)
                 || type === activeFilter;
             if (!matchesType) return false;
-
-            if (!normalizedSearch) return true;
+            if (!normalizedSearch || remoteSearch) return true;
 
             const serviceId = getServiceId(item.itype as any);
             const service = serviceId === null ? undefined : servicesById[serviceId.toString()];
@@ -75,7 +92,7 @@ const ItemList: React.FC<ItemListProps> = ({ items, onItemClick, defaultFilter, 
             if (sortBy === 'price-high') return toPriceNumber(b) - toPriceNumber(a);
             return toListTime(b) - toListTime(a);
         });
-    }, [availableItems, activeFilter, searchTerm, sortBy, getItemType, toPriceNumber, toListTime, servicesById]);
+    }, [availableItems, activeFilter, searchTerm, sortBy, getItemType, toPriceNumber, toListTime, servicesById, remoteSearch]);
 
     React.useEffect(() => {
         setActiveFilter(initialFilter);
@@ -84,21 +101,27 @@ const ItemList: React.FC<ItemListProps> = ({ items, onItemClick, defaultFilter, 
     return (
         <section className="reveal-up mt-4 rounded-3xl border border-white/60 bg-white/75 p-4 shadow-lg backdrop-blur sm:p-5">
             <div className="mb-4 flex items-center justify-between gap-2">
-                <p className="text-xs font-bold uppercase tracking-[0.18em] text-slate-500">Browse by Category</p>
+                <div>
+                    <p className="text-xs font-bold uppercase tracking-[0.18em] text-slate-500">Browse Marketplace</p>
+                    {searchTerm.trim() && remoteSearch && <p className="mt-1 text-xs text-slate-500">Searching across all listings and service provider metadata.</p>}
+                </div>
                 <p className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide text-slate-600">
-                    {visibleItems.length} items
+                    {visibleItems.length} loaded
                 </p>
             </div>
 
-            <div className="sticky top-[5.1rem] z-20 -mx-4 mb-4 space-y-3 border-y border-slate-200/80 bg-white/90 px-4 py-3 backdrop-blur sm:static sm:mx-0 sm:space-y-0 sm:border-0 sm:bg-transparent sm:p-0">
+            <div className="sticky top-[5.1rem] z-20 -mx-4 mb-4 space-y-3 border-y border-slate-200/80 bg-white/90 px-4 py-3 backdrop-blur sm:static sm:mx-0 sm:space-y-3 sm:border-0 sm:bg-transparent sm:p-0">
                 <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
-                    <input
-                        type="text"
-                        value={searchTerm}
-                        onChange={(e) => setSearchTerm(e.target.value)}
-                        placeholder="Search products..."
-                        className="rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 outline-none transition focus:border-orange-400"
-                    />
+                    <div className="relative">
+                        <input
+                            type="search"
+                            value={searchTerm}
+                            onChange={(e) => setSearchTerm(e.target.value)}
+                            placeholder="Search items, services, providers..."
+                            className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 pr-10 text-sm text-slate-700 outline-none transition focus:border-orange-400 focus:ring-2 focus:ring-orange-100"
+                        />
+                        {searching && <span className="absolute right-3 top-2.5 h-4 w-4 animate-spin rounded-full border-2 border-slate-300 border-t-orange-500" aria-label="Searching marketplace" />}
+                    </div>
 
                     <select
                         value={sortBy}
@@ -124,22 +147,18 @@ const ItemList: React.FC<ItemListProps> = ({ items, onItemClick, defaultFilter, 
                 </div>
 
                 {!freeOnly && (
-                <div className="flex flex-wrap gap-2 reveal-delay-1">
-                {filters.map((filter) => (
-                    <button
-                        key={filter}
-                        type="button"
-                        onClick={() => setActiveFilter(filter)}
-                        className={`btn-modern-secondary rounded-full px-3 py-1.5 text-xs font-semibold uppercase tracking-wide transition ${
-                            activeFilter === filter
-                                ? 'commerce-gradient text-white shadow-md'
-                                : 'border border-slate-300 bg-white text-slate-700 hover:border-orange-400 hover:text-orange-700'
-                        }`}
-                    >
-                        {(filter === 'all' ? 'All' : filter.charAt(0).toUpperCase() + filter.slice(1)) + ` (${filterCounts[filter] ?? 0})`}
-                    </button>
-                ))}
-                </div>
+                    <div className="flex flex-wrap gap-2 reveal-delay-1">
+                        {filters.map((filter) => (
+                            <button
+                                key={filter}
+                                type="button"
+                                onClick={() => setActiveFilter(filter)}
+                                className={`btn-modern-secondary rounded-full px-3 py-1.5 text-xs font-semibold uppercase tracking-wide transition ${activeFilter === filter ? 'commerce-gradient text-white shadow-md' : 'border border-slate-300 bg-white text-slate-700 hover:border-orange-400 hover:text-orange-700'}`}
+                            >
+                                {(filter === 'all' ? 'All' : filter.charAt(0).toUpperCase() + filter.slice(1)) + ` (${filterCounts[filter] ?? 0})`}
+                            </button>
+                        ))}
+                    </div>
                 )}
             </div>
 
@@ -159,13 +178,14 @@ const ItemList: React.FC<ItemListProps> = ({ items, onItemClick, defaultFilter, 
                 })}
             </div>
 
-            {visibleItems.length === 0 && (
+            {!searching && visibleItems.length === 0 && (
                 <div className="mt-4 rounded-2xl border border-slate-200 bg-white p-6 text-center">
-                    <p className="text-sm font-semibold text-slate-700">No matching items found.</p>
-                    <p className="mt-1 text-xs text-slate-500">Try another keyword, category, or sort option.</p>
+                    <p className="text-sm font-semibold text-slate-700">No matching listings found.</p>
+                    <p className="mt-1 text-xs text-slate-500">Try another keyword or category.</p>
                 </div>
             )}
         </section>
     );
 };
+
 export default ItemList;

--- a/frontend/components/offers/ListItemForm.tsx
+++ b/frontend/components/offers/ListItemForm.tsx
@@ -44,67 +44,107 @@ function commaList(value: string): string[] {
     return value.split(',').map((part) => part.trim()).filter(Boolean);
 }
 
+const ITEM_OPTIONS = [
+    { value: LIST_ITEM_MERCHANDISE, label: 'Item', hint: 'Physical goods or merchandise' },
+    { value: LIST_ITEM_SERVICE, label: 'Service', hint: 'Work, appointments, or professional services' },
+    { value: LIST_ITEM_NFT, label: 'NFT', hint: 'A digital collectible or tokenized asset' },
+    { value: LIST_ITEM_COIN, label: 'Coin', hint: 'A fungible token or coin' },
+    { value: LIST_ITEM_OTHER, label: 'Other', hint: 'Anything that does not fit the categories above' },
+];
+
+const inputClass = 'w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm text-slate-900 outline-none transition focus:border-cyan-500 focus:ring-2 focus:ring-cyan-100';
+
 export default function ListItemForm(props) {
     const freeOnly = !!props.freeOnly;
     const { state: { escrow, principal } } = useGlobalContext();
     const { stablecoins } = useStablecoins(escrow);
-
+    const [step, setStep] = React.useState(1);
 
     const [values, setValues] = React.useState({
-        name: "",
-        description: "",
-        image: "",
-        tags: "",
-        itype: props.itype,
+        name: '',
+        description: '',
+        image: '',
+        tags: '',
+        itype: props.itype || LIST_ITEM_MERCHANDISE,
         price: 0,
         currency: CURRENCY_ICP,
-        location: "online",
-        city: "",
+        location: 'online',
+        city: '',
         status: LISTITEM_STATUS_LIST,
-        providerName: "",
-        providerPhone: "",
-        providerEmail: "",
-        providerWebsite: "",
-        serviceTypes: "",
-        keywords: "",
-        pricingModel: freeOnly ? "free" : "fixed",
+        providerName: '',
+        providerPhone: '',
+        providerEmail: '',
+        providerWebsite: '',
+        serviceTypes: '',
+        keywords: '',
+        pricingModel: freeOnly ? 'free' : 'fixed',
         hourlyRate: 0,
-        availability: "onDemand",
-        schedule: "",
-        coverageCities: "",
-        coverageRadius: "",
-        capacity: "",
+        availability: 'onDemand',
+        schedule: '',
+        coverageCities: '',
+        coverageRadius: '',
+        capacity: '',
     });
 
     const handleChange = (e) => {
         setValues({ ...values, [e.target.name]: e.target.value });
     };
 
+    const validateStep = (targetStep: number) => {
+        if (targetStep >= 1 && !values.name.trim()) {
+            toast.warn('Give your listing a name');
+            return false;
+        }
+        if (targetStep >= 2) {
+            if (!freeOnly && Number(values.price) < 0) {
+                toast.warn('Price cannot be negative');
+                return false;
+            }
+            if (values.location === 'physical' && !values.city.trim()) {
+                toast.warn('Add a city or pickup location');
+                return false;
+            }
+            if (values.itype === LIST_ITEM_SERVICE && !values.providerName.trim()) {
+                toast.warn('Add a provider or business name for this service');
+                return false;
+            }
+        }
+        return true;
+    };
+
+    const next = () => {
+        if (!validateStep(step)) return;
+        setStep((current) => Math.min(3, current + 1));
+    };
+
     const list = async () => {
-        if (!values.name || values.name == "") { toast.warn("name is required"); return; }
-        if (!freeOnly && values.price < 0) { toast.warn("Price cannot be negative"); return; }
-        if (values.itype === LIST_ITEM_SERVICE && !principal) { toast.warn("Sign in to list a service"); return; }
+        if (!validateStep(2)) return;
+        if (values.itype === LIST_ITEM_SERVICE && !principal) {
+            toast.warn('Sign in to list a service');
+            return;
+        }
 
         const currency = buildCurrencyVariant(values.currency, stablecoins);
         const base = ledgerBase(values.currency, stablecoins);
-        const itemPrice = freeOnly ? BigInt(0) : BigInt(Math.floor(values.price * base));
+        const itemPrice = freeOnly ? BigInt(0) : BigInt(Math.floor(Number(values.price) * base));
         let serviceId = BigInt(0);
 
         if (values.itype === LIST_ITEM_SERVICE) {
-            const pricing = values.pricingModel === "free" ? { free: null } :
-                values.pricingModel === "donation" ? { donation: null } :
-                values.pricingModel === "hourly" ? { hourly: BigInt(Math.floor(Number(values.hourlyRate || 0) * base)) } :
-                values.pricingModel === "quote" ? { quote: null } :
+            const pricing = freeOnly ? { free: null } :
+                values.pricingModel === 'free' ? { free: null } :
+                values.pricingModel === 'donation' ? { donation: null } :
+                values.pricingModel === 'hourly' ? { hourly: BigInt(Math.floor(Number(values.hourlyRate || 0) * base)) } :
+                values.pricingModel === 'quote' ? { quote: null } :
                 { fixed: itemPrice };
-            const availability: any = values.availability === "always" ? [{ always: null }] :
-                values.availability === "schedule" ? [{ schedule: commaList(values.schedule) }] :
-                values.availability === "none" ? [] :
+            const availability: any = values.availability === 'always' ? [{ always: null }] :
+                values.availability === 'schedule' ? [{ schedule: commaList(values.schedule) }] :
+                values.availability === 'none' ? [] :
                 [{ onDemand: null }];
             const coverageCities = commaList(values.coverageCities);
-            const coverage: any = coverageCities.length || values.coverageRadius !== ""
-                ? [{ cities: coverageCities, radius: values.coverageRadius === "" ? [] : [BigInt(values.coverageRadius)] }]
+            const coverage: any = coverageCities.length || values.coverageRadius !== ''
+                ? [{ cities: coverageCities, radius: values.coverageRadius === '' ? [] : [BigInt(values.coverageRadius)] }]
                 : [];
-            const capacity: any = values.capacity === "" ? [] : [BigInt(values.capacity)];
+            const capacity: any = values.capacity === '' ? [] : [BigInt(values.capacity)];
             const serviceRes = await escrow.createService({
                 provider: {
                     name: values.providerName.trim(),
@@ -120,316 +160,254 @@ export default function ListItemForm(props) {
                 capacity,
             });
             if (!isCanisterOkResult(serviceRes)) {
-                toast.error(getCanisterErrorMessage(serviceRes, "Failed to create service info"));
+                toast.error(getCanisterErrorMessage(serviceRes, 'Failed to create service info'));
                 return;
             }
             serviceId = serviceRes.ok;
         }
 
-        const listype = values.itype == LIST_ITEM_NFT ? {"nft": null}:
-                        values.itype == LIST_ITEM_COIN ? {"coin": null}:
-                        values.itype == LIST_ITEM_MERCHANDISE ? {"merchandise": null}:
-                        values.itype == LIST_ITEM_SERVICE ? {"service": serviceId}:{"other": null}
-        
-        const location = values.location === "online"
-            ? { online: null }
-            : { physical: values.city };
-        let i = {
-            name: values.name,
-            description: values.description,
-            image: values.image,
+        const listype = values.itype === LIST_ITEM_NFT ? { nft: null } :
+            values.itype === LIST_ITEM_COIN ? { coin: null } :
+            values.itype === LIST_ITEM_MERCHANDISE ? { merchandise: null } :
+            values.itype === LIST_ITEM_SERVICE ? { service: serviceId } : { other: null };
+        const location = values.location === 'online' ? { online: null } : { physical: values.city.trim() };
+
+        props.submit({
+            name: values.name.trim(),
+            description: values.description.trim(),
+            image: values.image.trim(),
             tags: commaList(values.tags),
             itype: listype,
             price: itemPrice,
-            currency: currency,
-            location: location,
-            status: { "list": null }
-        };
-        props.submit(i);
+            currency,
+            location,
+            status: { list: null },
+        });
     };
 
+    const stepMeta = [
+        { number: 1, label: 'What' },
+        { number: 2, label: 'Terms' },
+        { number: 3, label: 'Review' },
+    ];
+
     return (
-        <div className="p-2">
-            <div className="grid grid-cols-1 gap-3 sm:grid-cols-12">
-                <div className="sm:col-span-3">
-                    <label className="mb-1 block text-sm font-medium text-slate-700">Type</label>
-                    <select
-                        value={values.itype}
-                        name="itype"
-                        onChange={handleChange}
-                        className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-cyan-500"
-                    >
-                        <option value={LIST_ITEM_NFT}>{LIST_ITEM_NFT}</option>
-                        <option value={LIST_ITEM_COIN}>{LIST_ITEM_COIN}</option>
-                        <option value={LIST_ITEM_MERCHANDISE}>{LIST_ITEM_MERCHANDISE}</option>
-                        <option value={LIST_ITEM_SERVICE}>{LIST_ITEM_SERVICE}</option>
-                        <option value={LIST_ITEM_OTHER}>{LIST_ITEM_OTHER}</option>
-                    </select>
-                </div>
-
-                <div className="sm:col-span-9">
-                    <label className="mb-1 block text-sm font-medium text-slate-700">Name</label>
-                    <input
-                        name="name"
-                        value={values.name}
-                        onChange={handleChange}
-                        className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-cyan-500"
-                    />
-                </div>
-
-                {!freeOnly && (
-                    <>
-                        <div className="sm:col-span-6">
-                            <label className="mb-1 block text-sm font-medium text-slate-700">Price</label>
-                            <input
-                                name="price"
-                                type="number"
-                                value={values.price}
-                                onChange={handleChange}
-                                className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-cyan-500"
-                            />
-                        </div>
-
-                        <div className="sm:col-span-6">
-                            <label className="mb-1 block text-sm font-medium text-slate-700">Currency</label>
-                            <select
-                                value={values.currency}
-                                name="currency"
-                                onChange={handleChange}
-                                className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-cyan-500"
-                            >
-                                <option value={CURRENCY_ICP}>{CURRENCY_ICP}</option>
-                                <option value={CURRENCY_ICET}>{CURRENCY_ICET}</option>
-                                {Object.values(stablecoins).map(sc => (
-                                    <option key={sc.symbol} value={sc.symbol}>{sc.symbol}</option>
-                                ))}
-                            </select>
-                        </div>
-                    </>
-                )}
-
-                <div className="sm:col-span-12">
-                    <label className="mb-1 block text-sm font-medium text-slate-700">Image url</label>
-                    <input
-                        name="image"
-                        value={values.image}
-                        onChange={handleChange}
-                        className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-cyan-500"
-                    />
-                </div>
-
-                <div className="sm:col-span-12">
-                    <label className="mb-1 block text-sm font-medium text-slate-700">Tags</label>
-                    <input
-                        name="tags"
-                        value={values.tags}
-                        onChange={handleChange}
-                        placeholder="Comma-separated tags, e.g. vintage, local, handmade"
-                        className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-cyan-500"
-                    />
-                </div>
-
-                <div className="sm:col-span-12">
-                    <label className="mb-1 block text-sm font-medium text-slate-700">Location</label>
-                    <div className="flex gap-2">
-                        <select
-                            value={values.location}
-                            name="location"
-                            onChange={handleChange}
-                            className="rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-cyan-500"
-                        >
-                            <option value="online">Online</option>
-                            <option value="physical">Physical</option>
-                        </select>
-                        {values.location === "physical" && (
-                            <input
-                                name="city"
-                                placeholder="where it is (e.g City, town, etc.)"
-                                value={values.city}
-                                onChange={handleChange}
-                                className="flex-1 rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-cyan-500"
-                            />
-                        )}
-                    </div>
-                </div>
-
-                <div className="sm:col-span-12">
-                    <label className="mb-1 block text-sm font-medium text-slate-700">Description</label>
-                    <input
-                        name="description"
-                        value={values.description}
-                        onChange={handleChange}
-                        className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-cyan-500"
-                    />
-                </div>
-
-                {values.itype === LIST_ITEM_SERVICE && (
-                    <div className="sm:col-span-12 rounded-xl border border-cyan-100 bg-cyan-50/60 p-3">
-                        <p className="mb-3 text-sm font-bold text-slate-800">Service details</p>
-                        <div className="grid grid-cols-1 gap-3 sm:grid-cols-12">
-
-                            <div className="sm:col-span-6">
-                                <label className="mb-1 block text-sm font-medium text-slate-700">Provider name</label>
-                                <input
-                                    name="providerName"
-                                    value={values.providerName}
-                                    onChange={handleChange}
-                                    placeholder="Business or contact name"
-                                    className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-cyan-500"
-                                />
-                            </div>
-                            <div className="sm:col-span-6">
-                                <label className="mb-1 block text-sm font-medium text-slate-700">Provider phone</label>
-                                <input
-                                    name="providerPhone"
-                                    value={values.providerPhone}
-                                    onChange={handleChange}
-                                    placeholder="Optional phone number"
-                                    className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-cyan-500"
-                                />
-                            </div>
-                            <div className="sm:col-span-6">
-                                <label className="mb-1 block text-sm font-medium text-slate-700">Provider email</label>
-                                <input
-                                    name="providerEmail"
-                                    type="email"
-                                    value={values.providerEmail}
-                                    onChange={handleChange}
-                                    placeholder="Optional email"
-                                    className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-cyan-500"
-                                />
-                            </div>
-                            <div className="sm:col-span-6">
-                                <label className="mb-1 block text-sm font-medium text-slate-700">Provider website</label>
-                                <input
-                                    name="providerWebsite"
-                                    value={values.providerWebsite}
-                                    onChange={handleChange}
-                                    placeholder="Optional website or profile"
-                                    className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-cyan-500"
-                                />
-                            </div>
-                            <div className="sm:col-span-6">
-                                <label className="mb-1 block text-sm font-medium text-slate-700">Service types</label>
-                                <input
-                                    name="serviceTypes"
-                                    value={values.serviceTypes}
-                                    onChange={handleChange}
-                                    placeholder="landscaping, hedge trimming"
-                                    className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-cyan-500"
-                                />
-                            </div>
-                            <div className="sm:col-span-6">
-                                <label className="mb-1 block text-sm font-medium text-slate-700">Keywords</label>
-                                <input
-                                    name="keywords"
-                                    value={values.keywords}
-                                    onChange={handleChange}
-                                    placeholder="hedge, cedar, free estimate"
-                                    className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-cyan-500"
-                                />
-                            </div>
-                            <div className="sm:col-span-4">
-                                <label className="mb-1 block text-sm font-medium text-slate-700">Pricing model</label>
-                                <select
-                                    name="pricingModel"
-                                    value={values.pricingModel}
-                                    onChange={handleChange}
-                                    className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-cyan-500"
-                                >
-                                    <option value="fixed">Fixed listing price</option>
-                                    <option value="hourly">Hourly</option>
-                                    <option value="quote">Quote</option>
-                                    <option value="donation">Donation</option>
-                                    <option value="free">Free</option>
-                                </select>
-                            </div>
-                            {values.pricingModel === "hourly" && (
-                                <div className="sm:col-span-4">
-                                    <label className="mb-1 block text-sm font-medium text-slate-700">Hourly rate</label>
-                                    <input
-                                        name="hourlyRate"
-                                        type="number"
-                                        value={values.hourlyRate}
-                                        onChange={handleChange}
-                                        className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-cyan-500"
-                                    />
-                                </div>
-                            )}
-                            <div className="sm:col-span-4">
-                                <label className="mb-1 block text-sm font-medium text-slate-700">Availability</label>
-                                <select
-                                    name="availability"
-                                    value={values.availability}
-                                    onChange={handleChange}
-                                    className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-cyan-500"
-                                >
-                                    <option value="onDemand">On demand</option>
-                                    <option value="always">Always</option>
-                                    <option value="schedule">Schedule</option>
-                                    <option value="none">Not specified</option>
-                                </select>
-                            </div>
-                            {values.availability === "schedule" && (
-                                <div className="sm:col-span-8">
-                                    <label className="mb-1 block text-sm font-medium text-slate-700">Schedule</label>
-                                    <input
-                                        name="schedule"
-                                        value={values.schedule}
-                                        onChange={handleChange}
-                                        placeholder="Mon-Fri, weekends, evenings"
-                                        className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-cyan-500"
-                                    />
-                                </div>
-                            )}
-                            <div className="sm:col-span-5">
-                                <label className="mb-1 block text-sm font-medium text-slate-700">Coverage cities</label>
-                                <input
-                                    name="coverageCities"
-                                    value={values.coverageCities}
-                                    onChange={handleChange}
-                                    placeholder="Walnut Grove, Langley"
-                                    className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-cyan-500"
-                                />
-                            </div>
-                            <div className="sm:col-span-3">
-                                <label className="mb-1 block text-sm font-medium text-slate-700">Radius</label>
-                                <input
-                                    name="coverageRadius"
-                                    type="number"
-                                    value={values.coverageRadius}
-                                    onChange={handleChange}
-                                    placeholder="km"
-                                    className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-cyan-500"
-                                />
-                            </div>
-                            <div className="sm:col-span-4">
-                                <label className="mb-1 block text-sm font-medium text-slate-700">Capacity</label>
-                                <input
-                                    name="capacity"
-                                    type="number"
-                                    value={values.capacity}
-                                    onChange={handleChange}
-                                    placeholder="optional"
-                                    className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-cyan-500"
-                                />
-                            </div>
-                        </div>
-                    </div>
-                )}
-
-                <div className="sm:col-span-12">
+        <div className="space-y-5 p-1 sm:p-2">
+            <div className="grid grid-cols-3 gap-2">
+                {stepMeta.map((item) => (
                     <button
+                        key={item.number}
                         type="button"
-                        onClick={list}
-                        disabled={!values.name}
-                        className="rounded-md bg-cyan-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-cyan-700 disabled:cursor-not-allowed disabled:bg-slate-300"
+                        onClick={() => item.number < step && setStep(item.number)}
+                        className={`rounded-xl border px-3 py-2 text-left transition ${step === item.number ? 'border-orange-400 bg-orange-50' : step > item.number ? 'border-emerald-200 bg-emerald-50' : 'border-slate-200 bg-slate-50'}`}
                     >
-                        {freeOnly ? 'Give Away' : 'List'}
+                        <span className="block text-[10px] font-bold uppercase tracking-wide text-slate-500">Step {item.number}</span>
+                        <span className="block text-sm font-semibold text-slate-800">{item.label}</span>
                     </button>
-                </div>
+                ))}
+            </div>
+
+            {step === 1 && (
+                <section className="space-y-4">
+                    <div>
+                        <h4 className="text-lg font-bold text-slate-900">What are you offering?</h4>
+                        <p className="mt-1 text-sm text-slate-500">Start with what a buyer needs to recognize the listing.</p>
+                    </div>
+
+                    <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                        {ITEM_OPTIONS.map((option) => (
+                            <button
+                                key={option.value}
+                                type="button"
+                                onClick={() => setValues((current) => ({ ...current, itype: option.value }))}
+                                className={`rounded-xl border p-3 text-left transition ${values.itype === option.value ? 'border-cyan-500 bg-cyan-50 ring-1 ring-cyan-100' : 'border-slate-200 bg-white hover:border-slate-300'}`}
+                            >
+                                <span className="block text-sm font-semibold text-slate-900">{option.label}</span>
+                                <span className="mt-1 block text-xs leading-5 text-slate-500">{option.hint}</span>
+                            </button>
+                        ))}
+                    </div>
+
+                    <div>
+                        <label className="mb-1 block text-sm font-medium text-slate-700">Listing name</label>
+                        <input name="name" value={values.name} onChange={handleChange} placeholder="What should buyers see first?" className={inputClass} />
+                    </div>
+
+                    <div>
+                        <label className="mb-1 block text-sm font-medium text-slate-700">Description</label>
+                        <textarea name="description" value={values.description} onChange={handleChange} rows={4} placeholder="Describe condition, scope, delivery expectations, or anything important to the agreement." className={inputClass} />
+                    </div>
+
+                    <div>
+                        <label className="mb-1 block text-sm font-medium text-slate-700">Image URL <span className="font-normal text-slate-400">optional</span></label>
+                        <input name="image" value={values.image} onChange={handleChange} placeholder="https://…" className={inputClass} />
+                    </div>
+                </section>
+            )}
+
+            {step === 2 && (
+                <section className="space-y-4">
+                    <div>
+                        <h4 className="text-lg font-bold text-slate-900">Price and delivery</h4>
+                        <p className="mt-1 text-sm text-slate-500">Define the terms buyers need before entering escrow.</p>
+                    </div>
+
+                    {!freeOnly && (
+                        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                            <div>
+                                <label className="mb-1 block text-sm font-medium text-slate-700">Price</label>
+                                <input name="price" type="number" min="0" step="any" value={values.price} onChange={handleChange} className={inputClass} />
+                            </div>
+                            <div>
+                                <label className="mb-1 block text-sm font-medium text-slate-700">Currency</label>
+                                <select value={values.currency} name="currency" onChange={handleChange} className={inputClass}>
+                                    <option value={CURRENCY_ICP}>{CURRENCY_ICP}</option>
+                                    <option value={CURRENCY_ICET}>{CURRENCY_ICET}</option>
+                                    {Object.values(stablecoins).map(sc => <option key={sc.symbol} value={sc.symbol}>{sc.symbol}</option>)}
+                                </select>
+                            </div>
+                        </div>
+                    )}
+
+                    {freeOnly && (
+                        <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm font-semibold text-emerald-800">This listing will be published as FREE.</div>
+                    )}
+
+                    <div>
+                        <label className="mb-1 block text-sm font-medium text-slate-700">Delivery / location</label>
+                        <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+                            <select value={values.location} name="location" onChange={handleChange} className={inputClass}>
+                                <option value="online">Online</option>
+                                <option value="physical">Physical / local</option>
+                            </select>
+                            {values.location === 'physical' && (
+                                <input name="city" placeholder="City or pickup area" value={values.city} onChange={handleChange} className={`${inputClass} sm:col-span-2`} />
+                            )}
+                        </div>
+                    </div>
+
+                    <div>
+                        <label className="mb-1 block text-sm font-medium text-slate-700">Tags <span className="font-normal text-slate-400">optional</span></label>
+                        <input name="tags" value={values.tags} onChange={handleChange} placeholder="vintage, local, handmade" className={inputClass} />
+                    </div>
+
+                    {values.itype === LIST_ITEM_SERVICE && (
+                        <div className="space-y-4 rounded-2xl border border-cyan-100 bg-cyan-50/60 p-4">
+                            <div>
+                                <p className="text-sm font-bold text-slate-900">Service essentials</p>
+                                <p className="mt-1 text-xs text-slate-500">Keep the marketplace-facing details simple; operational metadata is optional.</p>
+                            </div>
+                            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                                <div>
+                                    <label className="mb-1 block text-sm font-medium text-slate-700">Provider / business name</label>
+                                    <input name="providerName" value={values.providerName} onChange={handleChange} placeholder="Business or contact name" className={inputClass} />
+                                </div>
+                                <div>
+                                    <label className="mb-1 block text-sm font-medium text-slate-700">Service types</label>
+                                    <input name="serviceTypes" value={values.serviceTypes} onChange={handleChange} placeholder="landscaping, hedge trimming" className={inputClass} />
+                                </div>
+                                {!freeOnly && (
+                                    <div>
+                                        <label className="mb-1 block text-sm font-medium text-slate-700">Pricing model</label>
+                                        <select name="pricingModel" value={values.pricingModel} onChange={handleChange} className={inputClass}>
+                                            <option value="fixed">Fixed listing price</option>
+                                            <option value="hourly">Hourly</option>
+                                            <option value="quote">Quote</option>
+                                            <option value="donation">Donation</option>
+                                            <option value="free">Free</option>
+                                        </select>
+                                    </div>
+                                )}
+                                {values.pricingModel === 'hourly' && !freeOnly && (
+                                    <div>
+                                        <label className="mb-1 block text-sm font-medium text-slate-700">Hourly rate</label>
+                                        <input name="hourlyRate" type="number" min="0" value={values.hourlyRate} onChange={handleChange} className={inputClass} />
+                                    </div>
+                                )}
+                                <div>
+                                    <label className="mb-1 block text-sm font-medium text-slate-700">Availability</label>
+                                    <select name="availability" value={values.availability} onChange={handleChange} className={inputClass}>
+                                        <option value="onDemand">On demand</option>
+                                        <option value="always">Always</option>
+                                        <option value="schedule">Schedule</option>
+                                        <option value="none">Not specified</option>
+                                    </select>
+                                </div>
+                                {values.availability === 'schedule' && (
+                                    <div>
+                                        <label className="mb-1 block text-sm font-medium text-slate-700">Schedule</label>
+                                        <input name="schedule" value={values.schedule} onChange={handleChange} placeholder="Mon-Fri, evenings" className={inputClass} />
+                                    </div>
+                                )}
+                            </div>
+
+                            <details className="rounded-xl border border-cyan-100 bg-white/80 p-3">
+                                <summary className="cursor-pointer text-sm font-semibold text-slate-700">More service details</summary>
+                                <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
+                                    <input name="providerPhone" value={values.providerPhone} onChange={handleChange} placeholder="Phone (optional)" className={inputClass} />
+                                    <input name="providerEmail" type="email" value={values.providerEmail} onChange={handleChange} placeholder="Email (optional)" className={inputClass} />
+                                    <input name="providerWebsite" value={values.providerWebsite} onChange={handleChange} placeholder="Website (optional)" className={inputClass} />
+                                    <input name="keywords" value={values.keywords} onChange={handleChange} placeholder="Search keywords" className={inputClass} />
+                                    <input name="coverageCities" value={values.coverageCities} onChange={handleChange} placeholder="Coverage cities" className={inputClass} />
+                                    <input name="coverageRadius" type="number" min="0" value={values.coverageRadius} onChange={handleChange} placeholder="Radius (km)" className={inputClass} />
+                                    <input name="capacity" type="number" min="0" value={values.capacity} onChange={handleChange} placeholder="Capacity (optional)" className={inputClass} />
+                                </div>
+                            </details>
+                        </div>
+                    )}
+                </section>
+            )}
+
+            {step === 3 && (
+                <section className="space-y-4">
+                    <div>
+                        <h4 className="text-lg font-bold text-slate-900">Review and publish</h4>
+                        <p className="mt-1 text-sm text-slate-500">Check the buyer-facing summary before it goes live.</p>
+                    </div>
+
+                    <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+                        <div className="flex flex-wrap items-start justify-between gap-3">
+                            <div>
+                                <p className="text-xs font-bold uppercase tracking-wide text-slate-500">{ITEM_OPTIONS.find((option) => option.value === values.itype)?.label ?? 'Listing'}</p>
+                                <p className="mt-1 text-xl font-extrabold text-slate-900">{values.name}</p>
+                            </div>
+                            <p className={`rounded-full px-3 py-1 text-sm font-bold ${freeOnly ? 'bg-emerald-100 text-emerald-700' : 'bg-white text-slate-800'}`}>
+                                {freeOnly ? 'FREE' : `${values.price} ${values.currency}`}
+                            </p>
+                        </div>
+                        <p className="mt-3 text-sm leading-6 text-slate-600">{values.description || 'No description added.'}</p>
+                        <div className="mt-3 flex flex-wrap gap-2 text-xs text-slate-500">
+                            <span className="rounded-full bg-white px-2.5 py-1">{values.location === 'online' ? 'Online' : values.city}</span>
+                            {commaList(values.tags).map((tag) => <span key={tag} className="rounded-full bg-white px-2.5 py-1">#{tag}</span>)}
+                            {values.itype === LIST_ITEM_SERVICE && values.providerName && <span className="rounded-full bg-white px-2.5 py-1">Provided by {values.providerName}</span>}
+                        </div>
+                    </div>
+
+                    <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-xs leading-5 text-emerald-800">
+                        Publishing creates the listing on-chain. A paid buyer will then enter the guided escrow flow; a free listing uses the claim workflow.
+                    </div>
+                </section>
+            )}
+
+            <div className="flex flex-col-reverse gap-2 border-t border-slate-200 pt-4 sm:flex-row sm:items-center sm:justify-between">
+                <button
+                    type="button"
+                    onClick={() => setStep((current) => Math.max(1, current - 1))}
+                    disabled={step === 1}
+                    className="rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-700 transition hover:bg-slate-50 disabled:invisible"
+                >
+                    Back
+                </button>
+                {step < 3 ? (
+                    <button type="button" onClick={next} className="btn-modern-primary commerce-gradient rounded-xl px-5 py-2.5 text-sm font-semibold text-white shadow-sm">
+                        Continue
+                    </button>
+                ) : (
+                    <button type="button" onClick={list} className="btn-modern-primary commerce-gradient rounded-xl px-5 py-2.5 text-sm font-semibold text-white shadow-sm">
+                        {freeOnly ? 'Publish Free Listing' : 'Publish Listing'}
+                    </button>
+                )}
             </div>
         </div>
-
     );
 }

--- a/frontend/components/offers/OfferDetail.tsx
+++ b/frontend/components/offers/OfferDetail.tsx
@@ -1,24 +1,18 @@
 import * as React from 'react';
-import { useGlobalContext, useEscrow, useMenu } from '../Store';
+import { useGlobalContext, useEscrow } from '../Store';
 import { toast } from 'react-toastify';
 import moment from 'moment';
-import { MENU_ORDERS, ORDER_DEFAULT_EXPIRED_DAYS } from '../../lib/constants';
+import { ORDER_DEFAULT_EXPIRED_DAYS } from '../../lib/constants';
 import { currencyBase, currencySymbol } from '../../lib/currencyUtils';
 import { getItemImageSrc } from '../../lib/itemImage';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import PrincipalName from '../PrincipalName';
 import { getCanisterErrorMessage, getThrownErrorMessage, isCanisterOkResult } from '../../lib/canisterResult';
 
-
-
 export default (props) => {
-
-    const { state: {
-        isAuthed,
-        principal
-    } } = useGlobalContext();
+    const { state: { isAuthed, principal } } = useGlobalContext();
     const escrow = useEscrow();
-    const { setMenu } = useMenu();
+    const navigate = useNavigate();
 
     const [loading, setLoading] = React.useState(false);
     const [claimModalOpen, setClaimModalOpen] = React.useState(false);
@@ -32,7 +26,7 @@ export default (props) => {
 
     const buyit = async () => {
         if (!isAuthed) {
-            toast.warn("Plseae login first");
+            toast.warn("Please login first");
             return;
         }
         setLoading(true);
@@ -45,11 +39,12 @@ export default (props) => {
                 expiration: BigInt(moment().add(ORDER_DEFAULT_EXPIRED_DAYS, "days").unix())
             });
             if (res["ok"] !== undefined) {
-                toast.success("Your order has been created, check your order list!");
+                toast.success("Order created. Continue in Orders to fund escrow.");
+                props.close?.();
+                navigate('/orders');
             } else {
-                toast.error(res["err"] ? res["err"] : "check console log for error message");
+                toast.error(res["err"] ? res["err"] : "Unable to create order");
             }
-            props.close ? props.close() : null;
         } catch (e) {
             console.error("create order error", e);
             toast.error("Failed to create order: " + (e instanceof Error ? e.message : String(e)));
@@ -71,12 +66,11 @@ export default (props) => {
                 if (claimMessage.trim()) {
                     try { await escrow.commentOnClaim(claimId, claimMessage.trim()); } catch (_) {}
                 }
-                toast.success("Claim sent! Redirecting to your claims list…");
-                props.close ? props.close() : null;
-                setMenu(MENU_ORDERS);
+                toast.success("Claim sent. Track the seller response in Orders.");
+                props.close?.();
+                navigate('/orders');
             } else {
                 toast.error(res["err"] ? res["err"] : "Failed to claim item");
-                props.close ? props.close() : null;
             }
         } finally {
             setLoading(false);
@@ -89,7 +83,7 @@ export default (props) => {
         setLoading(true);
         try {
             const res = await escrow.changeItemStatus(props.offer.id, { "pending": null });
-            if (res["ok"]) {
+            if (res["ok"] !== undefined) {
                 toast.success("Item set to hold");
                 setItemStatus("pending");
             } else {
@@ -130,12 +124,12 @@ export default (props) => {
         setLoading(true)
         try {
             const res = await escrow.changeItemStatus(props.offer.id, { "sold": null });
-            if (res["ok"]) {
+            if (res["ok"] !== undefined) {
                 setItemStatus("sold")
 
                 if (isFree) {
                     const closeResult = await closeMatchingFreeOrder();
-                    if (closeResult["ok"]) {
+                    if (closeResult["ok"] !== undefined && closeResult["ok"] !== false) {
                         toast.success("Item marked as sold and order closed")
                     } else {
                         toast.warn(closeResult["err"] ? `Item marked as sold, but order close failed: ${closeResult["err"]}` : "Item marked as sold, but order was not closed")
@@ -185,7 +179,7 @@ export default (props) => {
         try {
             const res = await escrow.changeItemStatus(props.offer.id, { "unlist": null });
             if (isCanisterOkResult(res)) {
-                toast.success("unlist this item");
+                toast.success("Item removed from marketplace");
                 setItemStatus("unlist");
             } else {
                 toast.error(getCanisterErrorMessage(res, "Failed to unlist item"));
@@ -196,7 +190,7 @@ export default (props) => {
                 const refreshed = await escrow.getItem(props.offer.id);
                 const updatedOffer = refreshed?.[0];
                 if (updatedOffer && Object.getOwnPropertyNames(updatedOffer.status)[0] === 'unlist') {
-                    toast.success("Item unlisted");
+                    toast.success("Item removed from marketplace");
                     setItemStatus('unlist');
                 } else {
                     toast.error(getThrownErrorMessage(e, "Failed to unlist item"));
@@ -266,7 +260,6 @@ export default (props) => {
                             alt={props.offer.name}
                         />
                     </div>
-
                 </div>
 
                 <div className="lg:col-span-5">

--- a/frontend/components/offers/OfferList.tsx
+++ b/frontend/components/offers/OfferList.tsx
@@ -16,6 +16,12 @@ type OfferListProps = {
   freeOnly?: boolean;
 }
 
+type LoadOptions = {
+  showError?: boolean;
+  background?: boolean;
+  query?: string;
+}
+
 const PAGE_SIZE = 20;
 
 export default ({ freeOnly = false }: OfferListProps) => {
@@ -32,39 +38,28 @@ export default ({ freeOnly = false }: OfferListProps) => {
   const [servicesById, setServicesById] = React.useState<Record<string, ServiceInfo>>({})
   const [page, setPage] = React.useState(1)
   const [hasMore, setHasMore] = React.useState(true)
+  const [searchTerm, setSearchTerm] = React.useState('')
+  const [searching, setSearching] = React.useState(false)
+  const requestRef = React.useRef(0)
 
-  React.useEffect(() => {
-    setPage(1)
-    loadOffers(1, true, { showError: false })
-  }, [freeOnly])
-
-  const saveList = async (data) => {
-    setOpenListForm(false)
-    setLoading(true)
-    try {
-      const res = await escrow.listItem(data)
-      if (isCanisterOkResult(res)) {
-        toast.success("Item has been listed")
-        setPage(1)
-        await loadOffers(1, true, { showError: false })
-      } else {
-        toast.error(getCanisterErrorMessage(res, "Failed to list item"))
-      }
-    } catch (err) {
-      toast.error(err?.toString() ?? "Unable to list item")
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  const loadOffers = async (
+  async function loadOffers(
     targetPage: number,
     replace = false,
-    { showError = true }: { showError?: boolean } = {},
-  ) => {
-    setLoading(true)
+    { showError = true, background = false, query = searchTerm }: LoadOptions = {},
+  ) {
+    const requestId = ++requestRef.current
+    const normalizedQuery = query.trim()
+    if (background) setSearching(true)
+    else setLoading(true)
+
     try {
-      const res = await escrow.getItemsWithAssociations(BigInt(targetPage))
+      const keywords = normalizedQuery.split(/[\s,]+/).filter(Boolean)
+      const res = keywords.length > 0
+        ? await escrow.searchItemsWithAssociations(keywords, [], [{ list: null }] as any, BigInt(targetPage))
+        : await escrow.getItemsWithAssociations(BigInt(targetPage))
+
+      if (requestId !== requestRef.current) return 0
+
       const incomingItems = res.map((entry) => entry.item)
       const incomingServices = Object.fromEntries(
         res.flatMap((entry) => entry.service[0]
@@ -84,11 +79,49 @@ export default ({ freeOnly = false }: OfferListProps) => {
       setHasMore(res.length === PAGE_SIZE)
       return res.length
     } catch (err) {
-      if (showError) {
+      if (requestId === requestRef.current && showError) {
         toast.error(err?.toString() ?? "Unable to load offers")
       }
       console.error("Unable to load offers", err)
       return 0
+    } finally {
+      if (background) {
+        if (requestId === requestRef.current) setSearching(false)
+      } else {
+        setLoading(false)
+      }
+    }
+  }
+
+  React.useEffect(() => {
+    const hasQuery = searchTerm.trim().length > 0
+    const timer = window.setTimeout(() => {
+      setPage(1)
+      loadOffers(1, true, {
+        showError: hasQuery,
+        background: hasQuery,
+        query: searchTerm,
+      })
+    }, hasQuery ? 300 : 0)
+
+    return () => window.clearTimeout(timer)
+  }, [freeOnly, searchTerm])
+
+  const saveList = async (data) => {
+    setOpenListForm(false)
+    setLoading(true)
+    try {
+      const res = await escrow.listItem(data)
+      if (isCanisterOkResult(res)) {
+        toast.success("Listing published")
+        setSearchTerm('')
+        setPage(1)
+        await loadOffers(1, true, { showError: false, query: '' })
+      } else {
+        toast.error(getCanisterErrorMessage(res, "Failed to list item"))
+      }
+    } catch (err) {
+      toast.error(err?.toString() ?? "Unable to list item")
     } finally {
       setLoading(false)
     }
@@ -96,10 +129,8 @@ export default ({ freeOnly = false }: OfferListProps) => {
 
   const loadMore = async () => {
     const nextPage = page + 1
-    const loaded = await loadOffers(nextPage, false)
-    if (loaded > 0) {
-      setPage(nextPage)
-    }
+    const loaded = await loadOffers(nextPage, false, { query: searchTerm })
+    if (loaded > 0) setPage(nextPage)
   }
 
   function buy(newOrder: NewOrder) {
@@ -142,14 +173,16 @@ export default ({ freeOnly = false }: OfferListProps) => {
     setOpenOrderForm(false)
   }
 
+  const visibleOffers = freeOnly ? offers.filter((offer) => offer.price === BigInt(0)) : offers
+
   return (
     <React.Fragment>
       <section className="reveal-up glass-panel rounded-3xl p-4 sm:p-5">
         <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
           <div>
-            <p className="text-xs font-bold uppercase tracking-[0.18em] text-orange-700">{freeOnly ? 'Free Item Menu' : 'Featured Catalog'}</p>
-            <h2 className="mt-1 text-2xl font-extrabold tracking-tight text-slate-900">{freeOnly ? 'Claim Free Items' : 'Explore Live Listings'}</h2>
-            <p className="mt-1 text-sm text-slate-600">{freeOnly ? 'Only zero-price listings. Claim in one click and complete delivery confirmation later.' : 'Browse items and services with escrow-first checkout protection.'}</p>
+            <p className="text-xs font-bold uppercase tracking-[0.18em] text-orange-700">{freeOnly ? 'Free Marketplace' : 'Marketplace'}</p>
+            <h2 className="mt-1 text-2xl font-extrabold tracking-tight text-slate-900">{freeOnly ? 'Claim Free Items' : 'Find an item or service'}</h2>
+            <p className="mt-1 text-sm text-slate-600">{freeOnly ? 'Browse zero-price listings and send a claim directly to the owner.' : 'Search the full marketplace, then let escrow guide the transaction.'}</p>
           </div>
 
           {isAuthed && (
@@ -158,14 +191,14 @@ export default ({ freeOnly = false }: OfferListProps) => {
                 onClick={() => setOpenListForm(true)}
                 className="btn-modern-primary commerce-gradient min-w-[170px] rounded-xl px-4 py-2.5 text-sm font-semibold text-white shadow-md"
               >
-                {freeOnly ? 'Give Away Item' : 'List Item'}
+                {freeOnly ? 'Give Something Away' : 'Create Listing'}
               </button>
               {!freeOnly && (
                 <button
                   onClick={() => setOpenOrderForm(true)}
                   className="btn-modern-secondary min-w-[170px] rounded-xl border border-teal-600/60 bg-white px-4 py-2.5 text-sm font-semibold text-teal-700 shadow-sm"
                 >
-                  Start Escrow Order
+                  Custom Escrow
                 </button>
               )}
             </div>
@@ -173,21 +206,31 @@ export default ({ freeOnly = false }: OfferListProps) => {
         </div>
       </section>
 
-      <ItemList items={freeOnly ? offers.filter(o => o.price === BigInt(0)) : offers} servicesById={servicesById} defaultFilter='all' freeOnly={freeOnly} />
+      <ItemList
+        items={visibleOffers}
+        servicesById={servicesById}
+        defaultFilter='all'
+        freeOnly={freeOnly}
+        searchTerm={searchTerm}
+        onSearchTermChange={setSearchTerm}
+        searching={searching}
+        remoteSearch
+      />
 
       {hasMore && (
         <div className="reveal-up reveal-delay-1 mt-4 flex items-center justify-center p-2">
           <button
             onClick={loadMore}
-            className="btn-modern-secondary rounded-xl border border-slate-300 bg-white px-5 py-2.5 text-sm font-semibold text-slate-700 shadow-sm transition hover:border-orange-500 hover:text-orange-700"
+            disabled={searching}
+            className="btn-modern-secondary rounded-xl border border-slate-300 bg-white px-5 py-2.5 text-sm font-semibold text-slate-700 shadow-sm transition hover:border-orange-500 hover:text-orange-700 disabled:opacity-50"
           >
-            Load More Listings
+            {searchTerm.trim() ? 'Load More Results' : 'Load More Listings'}
           </button>
         </div>
       )}
 
-      {!hasMore && offers.length > 0 && (
-        <p className="mt-4 text-center text-xs font-medium text-slate-500">You’ve reached the end of the current listings.</p>
+      {!hasMore && visibleOffers.length > 0 && (
+        <p className="mt-4 text-center text-xs font-medium text-slate-500">{searchTerm.trim() ? 'You’ve reached the end of these search results.' : 'You’ve reached the end of the current listings.'}</p>
       )}
 
       {openListForm && (
@@ -201,8 +244,8 @@ export default ({ freeOnly = false }: OfferListProps) => {
             >
               ×
             </button>
-            <h3 className="mb-1 text-lg font-bold text-slate-900">{freeOnly ? 'Give Away an Item' : 'Create a Listing'}</h3>
-            <p className="mb-4 text-sm text-slate-500">Add the essentials first. You can provide more detail when it helps buyers decide.</p>
+            <h3 className="mb-1 pr-10 text-lg font-bold text-slate-900">{freeOnly ? 'Give Something Away' : 'Create a Listing'}</h3>
+            <p className="mb-4 text-sm text-slate-500">Three short steps: describe it, set the terms, then review before publishing.</p>
             <ListItemForm submit={saveList} itype={LIST_ITEM_MERCHANDISE} freeOnly={freeOnly} />
           </div>
         </div>
@@ -219,8 +262,8 @@ export default ({ freeOnly = false }: OfferListProps) => {
             >
               ×
             </button>
-            <h3 className="mb-1 text-lg font-bold text-slate-900">New Escrow Contract</h3>
-            <p className="mb-4 text-sm text-slate-500">Create a direct escrow agreement with a buyer or seller.</p>
+            <h3 className="mb-1 pr-10 text-lg font-bold text-slate-900">New Escrow Contract</h3>
+            <p className="mb-4 text-sm text-slate-500">Choose the other party by profile instead of copying a Principal.</p>
             <OrderForm buy={buy} sell={sell} />
           </div>
         </div>

--- a/frontend/components/offers/OfferList.tsx
+++ b/frontend/components/offers/OfferList.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-
+import { useNavigate } from "react-router-dom"
 import ListItemForm from "./ListItemForm"
 import { toast } from "react-toastify"
 import { useEscrow, useLoading, useGlobalContext } from "../Store"
@@ -8,9 +8,7 @@ import ItemList from "../items/ItemList";
 import { NewOrder, NewSellOrder } from "../../api/escrow/service.did"
 import { Item } from "../../api/escrow/service.did"
 import { ServiceInfo } from "../../api/escrow/serviceModels"
-import {
-  LIST_ITEM_NFT,
-} from "../../lib/constants"
+import { LIST_ITEM_MERCHANDISE } from "../../lib/constants"
 import OrderForm from "../orders/OrderForm"
 import { getCanisterErrorMessage, isCanisterOkResult } from "../../lib/canisterResult"
 
@@ -18,24 +16,27 @@ type OfferListProps = {
   freeOnly?: boolean;
 }
 
+const PAGE_SIZE = 20;
+
 export default ({ freeOnly = false }: OfferListProps) => {
   const {
     state: { isAuthed },
   } = useGlobalContext()
   const escrow = useEscrow()
+  const navigate = useNavigate()
   const { setLoading } = useLoading()
   const [openListForm, setOpenListForm] = React.useState(false)
   const [openOrderForm, setOpenOrderForm] = React.useState(false)
 
-  const [itemType] = React.useState(LIST_ITEM_NFT)
   const [offers, setOffers] = React.useState<Item[]>([])
   const [servicesById, setServicesById] = React.useState<Record<string, ServiceInfo>>({})
-  const [page, setPage] = React.useState(1);
+  const [page, setPage] = React.useState(1)
+  const [hasMore, setHasMore] = React.useState(true)
 
   React.useEffect(() => {
-    loadOffers({ showError: false })
-  }, [page])
-
+    setPage(1)
+    loadOffers(1, true, { showError: false })
+  }, [freeOnly])
 
   const saveList = async (data) => {
     setOpenListForm(false)
@@ -44,7 +45,8 @@ export default ({ freeOnly = false }: OfferListProps) => {
       const res = await escrow.listItem(data)
       if (isCanisterOkResult(res)) {
         toast.success("Item has been listed")
-        await loadOffers({ showError: false })
+        setPage(1)
+        await loadOffers(1, true, { showError: false })
       } else {
         toast.error(getCanisterErrorMessage(res, "Failed to list item"))
       }
@@ -55,23 +57,48 @@ export default ({ freeOnly = false }: OfferListProps) => {
     }
   }
 
-  const loadOffers = async ({ showError = true }: { showError?: boolean } = {}) => {
+  const loadOffers = async (
+    targetPage: number,
+    replace = false,
+    { showError = true }: { showError?: boolean } = {},
+  ) => {
     setLoading(true)
     try {
-      const res = await escrow.getItemsWithAssociations(BigInt(page))
-      setOffers(res.map((entry) => entry.item))
-      setServicesById(Object.fromEntries(
+      const res = await escrow.getItemsWithAssociations(BigInt(targetPage))
+      const incomingItems = res.map((entry) => entry.item)
+      const incomingServices = Object.fromEntries(
         res.flatMap((entry) => entry.service[0]
           ? [[entry.service[0].id.toString(), entry.service[0]]]
           : []),
-      ))
+      )
+
+      setOffers((previous) => {
+        if (replace) return incomingItems
+        const byId = new Map(previous.map((item) => [item.id.toString(), item]))
+        incomingItems.forEach((item) => byId.set(item.id.toString(), item))
+        return Array.from(byId.values())
+      })
+      setServicesById((previous) => replace
+        ? incomingServices
+        : { ...previous, ...incomingServices })
+      setHasMore(res.length === PAGE_SIZE)
+      return res.length
     } catch (err) {
       if (showError) {
         toast.error(err?.toString() ?? "Unable to load offers")
       }
       console.error("Unable to load offers", err)
+      return 0
     } finally {
       setLoading(false)
+    }
+  }
+
+  const loadMore = async () => {
+    const nextPage = page + 1
+    const loaded = await loadOffers(nextPage, false)
+    if (loaded > 0) {
+      setPage(nextPage)
     }
   }
 
@@ -80,7 +107,8 @@ export default ({ freeOnly = false }: OfferListProps) => {
     escrow.buy(newOrder)
       .then((res) => {
         if (isCanisterOkResult(res)) {
-          toast.success("your order has created!")
+          toast.success("Order created. Continue in Orders.")
+          navigate('/orders')
         } else {
           toast.error(getCanisterErrorMessage(res, "Failed to create order"))
         }
@@ -99,7 +127,8 @@ export default ({ freeOnly = false }: OfferListProps) => {
     escrow.sell(newOrder)
       .then((res) => {
         if (isCanisterOkResult(res)) {
-          toast.success("your order has created!")
+          toast.success("Order created. Continue in Orders.")
+          navigate('/orders')
         } else {
           toast.error(getCanisterErrorMessage(res, "Failed to create order"))
         }
@@ -120,7 +149,7 @@ export default ({ freeOnly = false }: OfferListProps) => {
           <div>
             <p className="text-xs font-bold uppercase tracking-[0.18em] text-orange-700">{freeOnly ? 'Free Item Menu' : 'Featured Catalog'}</p>
             <h2 className="mt-1 text-2xl font-extrabold tracking-tight text-slate-900">{freeOnly ? 'Claim Free Items' : 'Explore Live Listings'}</h2>
-            <p className="mt-1 text-sm text-slate-600">{freeOnly ? 'Only zero-price listings. Claim in one click and complete delivery confirmation later.' : 'Handpicked offers with escrow-first checkout protection.'}</p>
+            <p className="mt-1 text-sm text-slate-600">{freeOnly ? 'Only zero-price listings. Claim in one click and complete delivery confirmation later.' : 'Browse items and services with escrow-first checkout protection.'}</p>
           </div>
 
           {isAuthed && (
@@ -146,24 +175,20 @@ export default ({ freeOnly = false }: OfferListProps) => {
 
       <ItemList items={freeOnly ? offers.filter(o => o.price === BigInt(0)) : offers} servicesById={servicesById} defaultFilter='all' freeOnly={freeOnly} />
 
-      <div className="reveal-up reveal-delay-1 mt-4 flex items-center justify-center gap-3 p-2">
-        <button
-          onClick={() => setPage(p => p - 1)}
-          disabled={page === 1}
-          className="btn-modern-secondary rounded-xl border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:border-orange-500 hover:text-orange-700 disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          Previous
-        </button>
-        <p className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-700">
-          Page {page}
-        </p>
-        <button
-          onClick={() => setPage(p => p + 1)}
-          className="btn-modern-secondary rounded-xl border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:border-orange-500 hover:text-orange-700"
-        >
-          Next
-        </button>
-      </div>
+      {hasMore && (
+        <div className="reveal-up reveal-delay-1 mt-4 flex items-center justify-center p-2">
+          <button
+            onClick={loadMore}
+            className="btn-modern-secondary rounded-xl border border-slate-300 bg-white px-5 py-2.5 text-sm font-semibold text-slate-700 shadow-sm transition hover:border-orange-500 hover:text-orange-700"
+          >
+            Load More Listings
+          </button>
+        </div>
+      )}
+
+      {!hasMore && offers.length > 0 && (
+        <p className="mt-4 text-center text-xs font-medium text-slate-500">You’ve reached the end of the current listings.</p>
+      )}
 
       {openListForm && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/55 p-4 backdrop-blur-sm" onClick={() => setOpenListForm(false)}>
@@ -172,11 +197,13 @@ export default ({ freeOnly = false }: OfferListProps) => {
               type="button"
               onClick={() => setOpenListForm(false)}
               className="absolute right-3 top-3 h-8 w-8 rounded-full text-slate-500 transition hover:bg-slate-100"
+              aria-label="Close listing form"
             >
-              x
+              ×
             </button>
-            <h3 className="mb-4 text-lg font-bold text-slate-900">Input Item Information</h3>
-            <ListItemForm submit={saveList} itype={itemType} freeOnly={freeOnly} />
+            <h3 className="mb-1 text-lg font-bold text-slate-900">{freeOnly ? 'Give Away an Item' : 'Create a Listing'}</h3>
+            <p className="mb-4 text-sm text-slate-500">Add the essentials first. You can provide more detail when it helps buyers decide.</p>
+            <ListItemForm submit={saveList} itype={LIST_ITEM_MERCHANDISE} freeOnly={freeOnly} />
           </div>
         </div>
       )}
@@ -188,10 +215,12 @@ export default ({ freeOnly = false }: OfferListProps) => {
               type="button"
               onClick={() => setOpenOrderForm(false)}
               className="absolute right-3 top-3 h-8 w-8 rounded-full text-slate-500 transition hover:bg-slate-100"
+              aria-label="Close escrow form"
             >
-              x
+              ×
             </button>
-            <h3 className="mb-4 text-lg font-bold text-slate-900">New Escrow Contract</h3>
+            <h3 className="mb-1 text-lg font-bold text-slate-900">New Escrow Contract</h3>
+            <p className="mb-4 text-sm text-slate-500">Create a direct escrow agreement with a buyer or seller.</p>
             <OrderForm buy={buy} sell={sell} />
           </div>
         </div>

--- a/frontend/components/offers/OfferList.tsx
+++ b/frontend/components/offers/OfferList.tsx
@@ -18,7 +18,6 @@ type OfferListProps = {
 
 type LoadOptions = {
   showError?: boolean;
-  background?: boolean;
   query?: string;
 }
 
@@ -45,12 +44,11 @@ export default ({ freeOnly = false }: OfferListProps) => {
   async function loadOffers(
     targetPage: number,
     replace = false,
-    { showError = true, background = false, query = searchTerm }: LoadOptions = {},
+    { showError = true, query = searchTerm }: LoadOptions = {},
   ) {
     const requestId = ++requestRef.current
     const normalizedQuery = query.trim()
-    if (background) setSearching(true)
-    else setLoading(true)
+    setSearching(true)
 
     try {
       const keywords = normalizedQuery.split(/[\s,]+/).filter(Boolean)
@@ -85,11 +83,7 @@ export default ({ freeOnly = false }: OfferListProps) => {
       console.error("Unable to load offers", err)
       return 0
     } finally {
-      if (background) {
-        if (requestId === requestRef.current) setSearching(false)
-      } else {
-        setLoading(false)
-      }
+      if (requestId === requestRef.current) setSearching(false)
     }
   }
 
@@ -99,7 +93,6 @@ export default ({ freeOnly = false }: OfferListProps) => {
       setPage(1)
       loadOffers(1, true, {
         showError: hasQuery,
-        background: hasQuery,
         query: searchTerm,
       })
     }, hasQuery ? 300 : 0)

--- a/frontend/components/orders/CounterpartyPicker.tsx
+++ b/frontend/components/orders/CounterpartyPicker.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Profile } from '../../api/profile/profile.did';
+import type { Profile } from '../../api/profile/profile.did';
 import { useOneblock } from '../Store';
 
 type CounterpartyPickerProps = {
@@ -17,24 +17,31 @@ export default function CounterpartyPicker({ label, value, onChange, excludePrin
     const [results, setResults] = React.useState<Profile[]>([]);
     const [selected, setSelected] = React.useState<Profile | null>(null);
     const [searching, setSearching] = React.useState(false);
+    const [hasSearched, setHasSearched] = React.useState(false);
 
     React.useEffect(() => {
         const normalized = query.trim();
         if (!oneblock || normalized.length < 2 || selected?.name === normalized) {
             setResults([]);
+            setHasSearched(false);
             return;
         }
 
         let cancelled = false;
         const timer = window.setTimeout(async () => {
             setSearching(true);
+            setHasSearched(false);
             try {
                 const profiles = await oneblock.searchProfilesByName(normalized);
                 if (!cancelled) {
                     setResults(profiles.filter((profile) => profile.owner.toString() !== excludePrincipal).slice(0, 8));
+                    setHasSearched(true);
                 }
             } catch (err) {
-                if (!cancelled) setResults([]);
+                if (!cancelled) {
+                    setResults([]);
+                    setHasSearched(true);
+                }
                 console.error('Unable to search profiles', err);
             } finally {
                 if (!cancelled) setSearching(false);
@@ -51,6 +58,7 @@ export default function CounterpartyPicker({ label, value, onChange, excludePrin
         setSelected(profile);
         setQuery(profile.name);
         setResults([]);
+        setHasSearched(false);
         onChange(profile.owner.toString());
     };
 
@@ -58,6 +66,7 @@ export default function CounterpartyPicker({ label, value, onChange, excludePrin
         setSelected(null);
         setQuery('');
         setResults([]);
+        setHasSearched(false);
         onChange('');
     };
 
@@ -87,6 +96,8 @@ export default function CounterpartyPicker({ label, value, onChange, excludePrin
                         onChange={(event) => {
                             setSelected(null);
                             setQuery(event.target.value);
+                            setHasSearched(false);
+                            if (value) onChange('');
                         }}
                         placeholder="Search a person or business by name"
                         autoComplete="off"
@@ -121,8 +132,8 @@ export default function CounterpartyPicker({ label, value, onChange, excludePrin
                         </div>
                     )}
 
-                    {!searching && query.trim().length >= 2 && results.length === 0 && (
-                        <p className="mt-1 text-xs text-slate-500">No profile selected yet. Try another name, or use the advanced Principal option below.</p>
+                    {!searching && hasSearched && results.length === 0 && (
+                        <p className="mt-1 text-xs text-slate-500">No matching profile. Try another name, or use the advanced Principal option below.</p>
                     )}
                 </div>
             )}

--- a/frontend/components/orders/CounterpartyPicker.tsx
+++ b/frontend/components/orders/CounterpartyPicker.tsx
@@ -32,9 +32,20 @@ export default function CounterpartyPicker({ label, value, onChange, excludePrin
             setSearching(true);
             setHasSearched(false);
             try {
-                const profiles = await oneblock.searchProfilesByName(normalized);
+                const profileId = normalized.replace(/^@/, '');
+                const [byName, byId] = await Promise.all([
+                    oneblock.searchProfilesByName(normalized),
+                    oneblock.getProfile(profileId),
+                ]);
                 if (!cancelled) {
-                    setResults(profiles.filter((profile) => profile.owner.toString() !== excludePrincipal).slice(0, 8));
+                    const merged = [...byId, ...byName];
+                    const unique = new Map<string, Profile>();
+                    merged.forEach((profile) => unique.set(profile.owner.toString(), profile));
+                    setResults(
+                        Array.from(unique.values())
+                            .filter((profile) => profile.owner.toString() !== excludePrincipal)
+                            .slice(0, 8),
+                    );
                     setHasSearched(true);
                 }
             } catch (err) {
@@ -99,7 +110,7 @@ export default function CounterpartyPicker({ label, value, onChange, excludePrin
                             setHasSearched(false);
                             if (value) onChange('');
                         }}
-                        placeholder="Search a person or business by name"
+                        placeholder="Search a person, business, or @profile"
                         autoComplete="off"
                         className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 pr-10 text-sm text-slate-900 outline-none transition focus:border-cyan-500 focus:ring-2 focus:ring-cyan-100"
                     />
@@ -133,7 +144,7 @@ export default function CounterpartyPicker({ label, value, onChange, excludePrin
                     )}
 
                     {!searching && hasSearched && results.length === 0 && (
-                        <p className="mt-1 text-xs text-slate-500">No matching profile. Try another name, or use the advanced Principal option below.</p>
+                        <p className="mt-1 text-xs text-slate-500">No matching profile. Try another name or @profile, or use the advanced Principal option below.</p>
                     )}
                 </div>
             )}

--- a/frontend/components/orders/CounterpartyPicker.tsx
+++ b/frontend/components/orders/CounterpartyPicker.tsx
@@ -1,0 +1,144 @@
+import * as React from 'react';
+import { Profile } from '../../api/profile/profile.did';
+import { useOneblock } from '../Store';
+
+type CounterpartyPickerProps = {
+    label: string;
+    value: string;
+    onChange: (principal: string) => void;
+    excludePrincipal?: string;
+};
+
+const truncate = (value: string) => value.length > 18 ? `${value.slice(0, 8)}…${value.slice(-6)}` : value;
+
+export default function CounterpartyPicker({ label, value, onChange, excludePrincipal }: CounterpartyPickerProps) {
+    const oneblock = useOneblock();
+    const [query, setQuery] = React.useState('');
+    const [results, setResults] = React.useState<Profile[]>([]);
+    const [selected, setSelected] = React.useState<Profile | null>(null);
+    const [searching, setSearching] = React.useState(false);
+
+    React.useEffect(() => {
+        const normalized = query.trim();
+        if (!oneblock || normalized.length < 2 || selected?.name === normalized) {
+            setResults([]);
+            return;
+        }
+
+        let cancelled = false;
+        const timer = window.setTimeout(async () => {
+            setSearching(true);
+            try {
+                const profiles = await oneblock.searchProfilesByName(normalized);
+                if (!cancelled) {
+                    setResults(profiles.filter((profile) => profile.owner.toString() !== excludePrincipal).slice(0, 8));
+                }
+            } catch (err) {
+                if (!cancelled) setResults([]);
+                console.error('Unable to search profiles', err);
+            } finally {
+                if (!cancelled) setSearching(false);
+            }
+        }, 250);
+
+        return () => {
+            cancelled = true;
+            window.clearTimeout(timer);
+        };
+    }, [excludePrincipal, oneblock, query, selected]);
+
+    const chooseProfile = (profile: Profile) => {
+        setSelected(profile);
+        setQuery(profile.name);
+        setResults([]);
+        onChange(profile.owner.toString());
+    };
+
+    const clearSelection = () => {
+        setSelected(null);
+        setQuery('');
+        setResults([]);
+        onChange('');
+    };
+
+    return (
+        <div>
+            <label className="mb-1 block text-sm font-medium text-slate-700">{label}</label>
+
+            {selected && value ? (
+                <div className="flex items-center justify-between gap-3 rounded-xl border border-emerald-200 bg-emerald-50 px-3 py-2.5">
+                    <div className="min-w-0">
+                        <p className="truncate text-sm font-semibold text-slate-900">{selected.name}</p>
+                        <p className="truncate text-xs text-slate-500">@{selected.id} · {truncate(value)}</p>
+                    </div>
+                    <button
+                        type="button"
+                        onClick={clearSelection}
+                        className="rounded-lg border border-emerald-300 bg-white px-2.5 py-1 text-xs font-semibold text-emerald-800 transition hover:bg-emerald-100"
+                    >
+                        Change
+                    </button>
+                </div>
+            ) : (
+                <div className="relative">
+                    <input
+                        type="search"
+                        value={query}
+                        onChange={(event) => {
+                            setSelected(null);
+                            setQuery(event.target.value);
+                        }}
+                        placeholder="Search a person or business by name"
+                        autoComplete="off"
+                        className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 pr-10 text-sm text-slate-900 outline-none transition focus:border-cyan-500 focus:ring-2 focus:ring-cyan-100"
+                    />
+                    {searching && (
+                        <span className="absolute right-3 top-3 h-4 w-4 animate-spin rounded-full border-2 border-slate-300 border-t-cyan-600" aria-label="Searching" />
+                    )}
+
+                    {results.length > 0 && (
+                        <div className="absolute left-0 right-0 top-[calc(100%+0.35rem)] z-30 max-h-64 overflow-auto rounded-xl border border-slate-200 bg-white p-1 shadow-xl">
+                            {results.map((profile) => (
+                                <button
+                                    key={profile.owner.toString()}
+                                    type="button"
+                                    onClick={() => chooseProfile(profile)}
+                                    className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left transition hover:bg-slate-50"
+                                >
+                                    {profile.pfp ? (
+                                        <img src={profile.pfp} alt="" className="h-9 w-9 rounded-full bg-slate-100 object-cover" />
+                                    ) : (
+                                        <span className="flex h-9 w-9 items-center justify-center rounded-full bg-slate-100 text-sm font-bold text-slate-600">
+                                            {profile.name.slice(0, 1).toUpperCase() || '?'}
+                                        </span>
+                                    )}
+                                    <span className="min-w-0">
+                                        <span className="block truncate text-sm font-semibold text-slate-900">{profile.name}</span>
+                                        <span className="block truncate text-xs text-slate-500">@{profile.id}</span>
+                                    </span>
+                                </button>
+                            ))}
+                        </div>
+                    )}
+
+                    {!searching && query.trim().length >= 2 && results.length === 0 && (
+                        <p className="mt-1 text-xs text-slate-500">No profile selected yet. Try another name, or use the advanced Principal option below.</p>
+                    )}
+                </div>
+            )}
+
+            <details className="mt-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2">
+                <summary className="cursor-pointer text-xs font-semibold text-slate-600">Advanced: enter Principal directly</summary>
+                <input
+                    value={value}
+                    onChange={(event) => {
+                        setSelected(null);
+                        onChange(event.target.value.trim());
+                    }}
+                    placeholder="aaaaa-aa…"
+                    className="mt-2 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 font-mono text-xs text-slate-800 outline-none focus:border-cyan-500"
+                />
+            </details>
+        </div>
+    );
+}

--- a/frontend/components/orders/CounterpartyPicker.tsx
+++ b/frontend/components/orders/CounterpartyPicker.tsx
@@ -20,6 +20,15 @@ export default function CounterpartyPicker({ label, value, onChange, excludePrin
     const [hasSearched, setHasSearched] = React.useState(false);
 
     React.useEffect(() => {
+        if (value) return;
+        setSelected(null);
+        setQuery('');
+        setResults([]);
+        setSearching(false);
+        setHasSearched(false);
+    }, [value]);
+
+    React.useEffect(() => {
         const normalized = query.trim();
         if (!oneblock || normalized.length < 2 || selected?.name === normalized) {
             setResults([]);

--- a/frontend/components/orders/OrderForm.tsx
+++ b/frontend/components/orders/OrderForm.tsx
@@ -180,6 +180,7 @@ export default function OrderForm(props) {
 
                 <div className="sm:col-span-12">
                     <CounterpartyPicker
+                        key={counterpartyRole}
                         label={`Choose the ${counterpartyRole}`}
                         value={counterpartyValue}
                         onChange={setCounterparty}

--- a/frontend/components/orders/OrderForm.tsx
+++ b/frontend/components/orders/OrderForm.tsx
@@ -12,8 +12,8 @@ import {
 } from '../../lib/constants';
 import { useGlobalContext } from '../Store';
 import { useStablecoins, StablecoinMap } from '../../lib/hooks/useStablecoins';
+import CounterpartyPicker from './CounterpartyPicker';
 
-/** Build the Candid Currency variant object expected by the backend. */
 function buildCurrencyVariant(currencyKey: string, icrc1Tokens: StablecoinMap): Record<string, any> {
     if (currencyKey === CURRENCY_ICP) return { ICP: null };
     if (currencyKey === CURRENCY_ICET) return { ICET: null };
@@ -30,7 +30,6 @@ function buildCurrencyVariant(currencyKey: string, icrc1Tokens: StablecoinMap): 
     return { ICP: null };
 }
 
-/** Return the ledger base (smallest units per whole token) for a given key. */
 function ledgerBase(currencyKey: string, icrc1Tokens: StablecoinMap): number {
     if (currencyKey === CURRENCY_ICET) return LEDGER_E6S;
     const info = icrc1Tokens[currencyKey];
@@ -42,27 +41,32 @@ export default function OrderForm(props) {
     const {
         state: { principal, escrow },
     } = useGlobalContext();
-
     const { stablecoins } = useStablecoins(escrow);
+    const principalText = principal?.toString() ?? '';
 
     const [state, setState] = React.useState({
         item: '',
         yourside: 'buyer',
-        buyer: principal.toText(),
+        buyer: principalText,
         seller: '',
         amount: 0,
         currency: CURRENCY_ICP,
     });
 
+    React.useEffect(() => {
+        if (!principalText) return;
+        setState((current) => current.yourside === 'buyer'
+            ? { ...current, buyer: principalText }
+            : { ...current, seller: principalText });
+    }, [principalText]);
+
     function handleChange(e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) {
         const { name, value } = e.target;
 
         if (name === 'yourside') {
-            if (value === 'buyer') {
-                setState({ ...state, yourside: value, buyer: principal.toText(), seller: '' });
-            } else {
-                setState({ ...state, yourside: value, seller: principal.toText(), buyer: '' });
-            }
+            setState((current) => value === 'buyer'
+                ? { ...current, yourside: value, buyer: principalText, seller: '' }
+                : { ...current, yourside: value, seller: principalText, buyer: '' });
             return;
         }
 
@@ -75,13 +79,31 @@ export default function OrderForm(props) {
         setState({ ...state, [name]: value });
     }
 
+    const setCounterparty = (value: string) => {
+        if (state.yourside === 'buyer') {
+            setState((current) => ({ ...current, seller: value }));
+        } else {
+            setState((current) => ({ ...current, buyer: value }));
+        }
+    };
+
     function createOrder() {
+        if (!principalText) {
+            toast.warn('Sign in before creating an escrow order');
+            return;
+        }
         if (!state.item.trim()) {
-            toast.warn('order item is required');
+            toast.warn('Describe what this escrow order is for');
             return;
         }
         if (state.amount <= 0) {
-            toast.warn('amount must be greater than 0');
+            toast.warn('Amount must be greater than 0');
+            return;
+        }
+
+        const counterparty = state.yourside === 'buyer' ? state.seller.trim() : state.buyer.trim();
+        if (!counterparty) {
+            toast.warn(`Choose the ${state.yourside === 'buyer' ? 'seller' : 'buyer'}`);
             return;
         }
 
@@ -92,110 +114,99 @@ export default function OrderForm(props) {
 
         try {
             if (state.yourside === 'buyer') {
-                const seller = Principal.fromText(state.seller.trim());
                 props.buy({
-                    seller,
-                    memo: state.item,
+                    seller: Principal.fromText(counterparty),
+                    memo: state.item.trim(),
                     amount,
                     currency,
                     expiration,
                 });
             } else {
-                const buyer = Principal.fromText(state.buyer.trim());
                 props.sell({
-                    buyer,
-                    memo: state.item,
+                    buyer: Principal.fromText(counterparty),
+                    memo: state.item.trim(),
                     amount,
                     currency,
                     expiration,
                 });
             }
         } catch {
-            toast.error('invalid principal');
+            toast.error('The selected account has an invalid Principal');
         }
     }
 
+    const counterpartyValue = state.yourside === 'buyer' ? state.seller : state.buyer;
+    const counterpartyRole = state.yourside === 'buyer' ? 'seller' : 'buyer';
+
     return (
-        <div className="space-y-4">
-            <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-900">
-                <p className="mb-3">
-                    Create a custom order to guard your fund with your buyer/seller in escrow smart contract. (e.g. house rental deposit, sale deposit...)
-                </p>
-                <div className="grid gap-2 text-xs sm:grid-cols-4">
-                    <div className="rounded-md bg-white px-3 py-2 text-center font-medium text-slate-700">Deposit Fund in Escrow</div>
-                    <div className="rounded-md bg-white px-3 py-2 text-center font-medium text-slate-700">Seller Deliver Item</div>
-                    <div className="rounded-md bg-white px-3 py-2 text-center font-medium text-slate-700">Buyer Receive Item</div>
-                    <div className="rounded-md bg-white px-3 py-2 text-center font-medium text-slate-700">Release Fund to Seller</div>
+        <div className="space-y-5">
+            <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-900">
+                <p className="font-semibold">Escrow keeps funds protected while both sides complete the agreement.</p>
+                <div className="mt-3 grid gap-2 text-xs sm:grid-cols-4">
+                    <div className="rounded-lg bg-white px-3 py-2 text-center font-medium text-slate-700">1. Buyer funds escrow</div>
+                    <div className="rounded-lg bg-white px-3 py-2 text-center font-medium text-slate-700">2. Seller delivers</div>
+                    <div className="rounded-lg bg-white px-3 py-2 text-center font-medium text-slate-700">3. Buyer confirms</div>
+                    <div className="rounded-lg bg-white px-3 py-2 text-center font-medium text-slate-700">4. Seller receives funds</div>
                 </div>
             </div>
 
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-12">
                 <div className="sm:col-span-12">
-                    <label className="mb-1 block text-sm font-medium text-slate-700">Describe your ordering item</label>
+                    <label className="mb-1 block text-sm font-medium text-slate-700">What is this agreement for?</label>
                     <input
                         name="item"
                         value={state.item}
                         onChange={handleChange}
-                        className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-cyan-500"
+                        placeholder="e.g. Website redesign deposit, used kayak, landscaping service"
+                        className="w-full rounded-xl border border-slate-300 px-3 py-2.5 text-sm text-slate-900 outline-none transition focus:border-cyan-500 focus:ring-2 focus:ring-cyan-100"
                     />
                 </div>
 
-                <div className="sm:col-span-4">
-                    <p className="mb-1 text-sm font-medium text-slate-700">Are you?</p>
-                    <div className="flex gap-4 text-sm">
-                        <label className="inline-flex items-center gap-2">
-                            <input type="radio" name="yourside" value="buyer" checked={state.yourside === 'buyer'} onChange={handleChange} />
-                            Buyer
-                        </label>
-                        <label className="inline-flex items-center gap-2">
-                            <input type="radio" name="yourside" value="seller" checked={state.yourside === 'seller'} onChange={handleChange} />
-                            Seller
-                        </label>
+                <div className="sm:col-span-12">
+                    <p className="mb-2 text-sm font-medium text-slate-700">Your role</p>
+                    <div className="grid grid-cols-2 gap-2">
+                        {['buyer', 'seller'].map((role) => (
+                            <label
+                                key={role}
+                                className={`cursor-pointer rounded-xl border px-4 py-3 text-sm transition ${state.yourside === role ? 'border-cyan-500 bg-cyan-50 text-cyan-900' : 'border-slate-200 bg-white text-slate-700 hover:border-slate-300'}`}
+                            >
+                                <input className="sr-only" type="radio" name="yourside" value={role} checked={state.yourside === role} onChange={handleChange} />
+                                <span className="block font-semibold">I’m the {role}</span>
+                                <span className="mt-0.5 block text-xs text-slate-500">{role === 'buyer' ? 'I will fund escrow' : 'I will deliver and receive funds'}</span>
+                            </label>
+                        ))}
                     </div>
                 </div>
 
-                {state.yourside === 'seller' && (
-                    <div className="sm:col-span-8">
-                        <label className="mb-1 block text-sm font-medium text-slate-700">the principal of buyer</label>
-                        <input
-                            name="buyer"
-                            value={state.buyer}
-                            onChange={handleChange}
-                            className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-cyan-500"
-                        />
-                    </div>
-                )}
+                <div className="sm:col-span-12">
+                    <CounterpartyPicker
+                        label={`Choose the ${counterpartyRole}`}
+                        value={counterpartyValue}
+                        onChange={setCounterparty}
+                        excludePrincipal={principalText}
+                    />
+                </div>
 
-                {state.yourside === 'buyer' && (
-                    <div className="sm:col-span-8">
-                        <label className="mb-1 block text-sm font-medium text-slate-700">the principal of seller</label>
-                        <input
-                            name="seller"
-                            value={state.seller}
-                            onChange={handleChange}
-                            className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-cyan-500"
-                        />
-                    </div>
-                )}
-
-                <div className="sm:col-span-6">
-                    <label className="mb-1 block text-sm font-medium text-slate-700">the amount of order</label>
+                <div className="sm:col-span-7">
+                    <label className="mb-1 block text-sm font-medium text-slate-700">Escrow amount</label>
                     <input
                         name="amount"
                         type="number"
+                        min="0"
+                        step="any"
                         value={state.amount}
                         onChange={handleChange}
-                        className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-cyan-500"
+                        className="w-full rounded-xl border border-slate-300 px-3 py-2.5 text-sm text-slate-900 outline-none transition focus:border-cyan-500 focus:ring-2 focus:ring-cyan-100"
                     />
                 </div>
 
-                <div className="sm:col-span-6">
+                <div className="sm:col-span-5">
                     <label className="mb-1 block text-sm font-medium text-slate-700">Currency</label>
                     <select
                         name="currency"
                         value={state.currency}
                         onChange={handleChange}
-                        className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-cyan-500"
+                        className="w-full rounded-xl border border-slate-300 px-3 py-2.5 text-sm text-slate-900 outline-none transition focus:border-cyan-500 focus:ring-2 focus:ring-cyan-100"
                     >
                         <option value={CURRENCY_ICP}>{CURRENCY_ICP}</option>
                         <option value={CURRENCY_ICET}>{CURRENCY_ICET}</option>
@@ -205,13 +216,19 @@ export default function OrderForm(props) {
                     </select>
                 </div>
 
+                <div className="sm:col-span-12 rounded-xl border border-slate-200 bg-slate-50 p-3 text-xs text-slate-600">
+                    <span className="font-semibold text-slate-800">You are the {state.yourside}.</span>{' '}
+                    Vansday will create the order now and guide both participants through each required action in Orders.
+                </div>
+
                 <div className="sm:col-span-12">
                     <button
                         type="button"
                         onClick={createOrder}
-                        className="rounded-md bg-cyan-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-cyan-700"
+                        disabled={!state.item.trim() || !counterpartyValue || state.amount <= 0}
+                        className="btn-modern-primary commerce-gradient w-full rounded-xl px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:-translate-y-0.5 disabled:cursor-not-allowed disabled:bg-slate-300 disabled:shadow-none sm:w-auto"
                     >
-                        Create
+                        Create Escrow Order
                     </button>
                 </div>
             </div>

--- a/frontend/components/orders/OrderList.tsx
+++ b/frontend/components/orders/OrderList.tsx
@@ -75,11 +75,15 @@ export default () => {
     }, []);
 
     React.useEffect(() => {
+        if (!principal) return;
+        setPage(1);
+        setHasOlderOrders(true);
         loadProcessingOrders();
         loadClaims();
-    }, []);
+    }, [principal]);
 
     async function loadProcessingOrders() {
+        if (!principal) return;
         setLoading(true)
         try {
             const os = await escrow.getOrders();
@@ -92,6 +96,7 @@ export default () => {
     };
 
     async function loadAllOrders() {
+        if (!principal) return;
         setLoading(true)
         try {
             const os = await escrow.getAllOrders(BigInt(page));
@@ -110,6 +115,7 @@ export default () => {
     };
 
     function loadClaims() {
+        if (!principal) return;
         setClaimsLoading(true);
         Promise.allSettled([
             escrow.getMyBuyerFreeItemClaims(),
@@ -174,6 +180,16 @@ export default () => {
             setLoading(false)
         }
     };
+
+    if (!principal) {
+        return (
+            <section className="mx-auto mt-8 max-w-2xl rounded-3xl border border-white/60 bg-white/85 p-6 text-center shadow-lg backdrop-blur">
+                <p className="text-xs font-bold uppercase tracking-[0.18em] text-orange-700">Order Action Center</p>
+                <h1 className="mt-2 text-2xl font-extrabold tracking-tight text-slate-900">Sign in to manage your escrow activity</h1>
+                <p className="mt-2 text-sm leading-6 text-slate-600">Your active orders, required actions, and free-item claims will appear here after your identity session is restored.</p>
+            </section>
+        );
+    }
 
     const needsActionCount = orders.filter(needsUserAction).length;
     const openOrderCount = orders.filter((order) => !isTerminalOrder(order)).length;

--- a/frontend/components/orders/OrderList.tsx
+++ b/frontend/components/orders/OrderList.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { toast } from 'react-toastify';
-import moment from 'moment';
 
-import { useEscrow } from '../Store';
+import { useEscrow, useGlobalContext } from '../Store';
 import OrderListItem from './OrderListItem';
 import OrderForm from './OrderForm';
 import ClaimCard from './ClaimCard';
@@ -18,20 +17,25 @@ import {
     ORDER_STATUS_CANCELED,
 } from '../../lib/constants';
 
+const PAGE_SIZE = 20;
+
 export default () => {
     const escrow = useEscrow();
-    const [orders, setOrders] = React.useState([])
+    const { state: { principal } } = useGlobalContext();
+    const [orders, setOrders] = React.useState<any[]>([])
     const [loading, setLoading] = React.useState(false)
     const [page, setPage] = React.useState(1)
+    const [hasOlderOrders, setHasOlderOrders] = React.useState(true)
 
     const [buyerClaims, setBuyerClaims] = React.useState<any[]>([]);
     const [sellerClaims, setSellerClaims] = React.useState<any[]>([]);
     const [claimsLoading, setClaimsLoading] = React.useState(false);
 
     const [openOrderForm, setOpenOrderForm] = React.useState(false);
-    const [statusFilter, setStatusFilter] = React.useState<string>('all');
+    const [statusFilter, setStatusFilter] = React.useState<string>('action');
 
     const STATUS_FILTERS = [
+        { label: 'Needs You', value: 'action' },
         { label: 'All', value: 'all' },
         { label: 'New', value: ORDER_STATUS_NEW },
         { label: 'Deposited', value: ORDER_STATUS_DEPOSITED },
@@ -43,27 +47,66 @@ export default () => {
         { label: 'Refunded', value: ORDER_STATUS_REFUNDED },
     ];
 
+    const getStatus = React.useCallback((order: any) => Object.getOwnPropertyNames(order.status)[0], []);
+
+    const isTerminalOrder = React.useCallback((order: any) => {
+        const status = getStatus(order);
+        return status === ORDER_STATUS_CLOSED
+            || status === ORDER_STATUS_CANCELED
+            || status === ORDER_STATUS_REFUNDED;
+    }, [getStatus]);
+
+    const needsUserAction = React.useCallback((order: any) => {
+        if (!principal || order.amount === BigInt(0)) return false;
+        const status = getStatus(order);
+        const isBuyer = order.buyer.toString() === principal.toString();
+        const isSeller = order.seller.toString() === principal.toString();
+
+        return (status === ORDER_STATUS_NEW && isBuyer)
+            || (status === ORDER_STATUS_DEPOSITED && isSeller)
+            || (status === ORDER_STATUS_DELIVERED && isBuyer)
+            || (status === ORDER_STATUS_RECEIVED && isSeller)
+            || (status === ORDER_STATUS_RELEASED && isSeller);
+    }, [getStatus, principal]);
+
+    const isClaimResolved = React.useCallback((claim: any): boolean => {
+        const isOptSet = (v: any) => v !== null && v !== undefined && (!Array.isArray(v) || v.length > 0);
+        return isOptSet(claim.closedAt) || isOptSet(claim.canceledAt);
+    }, []);
+
     React.useEffect(() => {
         loadProcessingOrders();
         loadClaims();
     }, []);
 
-    function loadProcessingOrders() {
+    async function loadProcessingOrders() {
         setLoading(true)
-        escrow.getOrders().then(os => {
+        try {
+            const os = await escrow.getOrders();
             setOrders(os)
+        } catch (err) {
+            toast.error(err?.toString() ?? 'Failed to load orders');
+        } finally {
             setLoading(false)
-        })
+        }
     };
 
-    function loadAllOrders() {
+    async function loadAllOrders() {
         setLoading(true)
-        escrow.getAllOrders(BigInt(page)).then(os => {
-            console.log(os)
-            setOrders(os)
-            setPage(page + 1)
+        try {
+            const os = await escrow.getAllOrders(BigInt(page));
+            setOrders((previous) => {
+                const byId = new Map(previous.map((order: any) => [order.id.toString(), order]));
+                os.forEach((order: any) => byId.set(order.id.toString(), order));
+                return Array.from(byId.values());
+            });
+            setPage((current) => current + 1)
+            setHasOlderOrders(os.length === PAGE_SIZE)
+        } catch (err) {
+            toast.error(err?.toString() ?? 'Failed to load older orders');
+        } finally {
             setLoading(false)
-        })
+        }
     };
 
     function loadClaims() {
@@ -94,52 +137,62 @@ export default () => {
         setSellerClaims((prev) => prev.map((c) => (c.id === updated.id ? updated : c)));
     };
 
-    function buy(newOrder: NewOrder) {
+    async function buy(newOrder: NewOrder) {
+        setLoading(true)
         try {
-            setLoading(true)
-            escrow.buy(newOrder).then(res => {
-                setLoading(false);
-                if (res["ok"]) {
-                    toast.success("your order has created!")
-                } else {
-                    toast.error(res["err"].toString());
-                }
-            });
-            setOpenOrderForm(false);
+            const res = await escrow.buy(newOrder);
+            if (res["ok"] !== undefined) {
+                toast.success("Order created. Next action is shown below.")
+                setOpenOrderForm(false)
+                setStatusFilter('action')
+                await loadProcessingOrders()
+            } else {
+                toast.error(res["err"]?.toString() ?? 'Failed to create order');
+            }
         } catch (err) {
-            toast.error(err.toString())
-        };
+            toast.error(err?.toString() ?? 'Failed to create order')
+        } finally {
+            setLoading(false)
+        }
     };
 
-    function sell(newOrder: NewSellOrder) {
+    async function sell(newOrder: NewSellOrder) {
+        setLoading(true)
         try {
-            setLoading(true)
-            escrow.sell(newOrder).then(res => {
-                setLoading(false);
-                if (res["ok"]) {
-                    toast.success("your order has created!")
-                } else {
-                    toast.error(res["err"].toString());
-                }
-            });
-            setOpenOrderForm(false);
+            const res = await escrow.sell(newOrder);
+            if (res["ok"] !== undefined) {
+                toast.success("Order created. Next action is shown below.")
+                setOpenOrderForm(false)
+                setStatusFilter('action')
+                await loadProcessingOrders()
+            } else {
+                toast.error(res["err"]?.toString() ?? 'Failed to create order');
+            }
         } catch (err) {
-            toast.error(err.toString())
-        };
+            toast.error(err?.toString() ?? 'Failed to create order')
+        } finally {
+            setLoading(false)
+        }
     };
 
-    const filteredOrders = statusFilter === 'all'
-        ? orders
-        : orders.filter((o: any) => Object.getOwnPropertyNames(o.status)[0] === statusFilter);
+    const needsActionCount = orders.filter(needsUserAction).length;
+    const openOrderCount = orders.filter((order) => !isTerminalOrder(order)).length;
+    const waitingOrderCount = Math.max(0, openOrderCount - needsActionCount);
+    const completeOrderCount = orders.filter(isTerminalOrder).length;
+    const openIncomingClaims = sellerClaims.filter((claim) => !isClaimResolved(claim)).length;
+    const openBuyerClaims = buyerClaims.filter((claim) => !isClaimResolved(claim)).length;
 
-    let ol = filteredOrders.map(o =>
-        <OrderListItem key={o.id} order={o} />
-    )
+    const filteredOrders = statusFilter === 'action'
+        ? orders.filter(needsUserAction)
+        : statusFilter === 'all'
+            ? orders
+            : orders.filter((o: any) => getStatus(o) === statusFilter);
 
-    const isClaimResolved = (claim: any): boolean => {
-        const isOptSet = (v: any) => v !== null && v !== undefined && (!Array.isArray(v) || v.length > 0);
-        return isOptSet(claim.closedAt) || isOptSet(claim.canceledAt);
-    };
+    const sortedOrders = [...filteredOrders].sort((a: any, b: any) => {
+        const actionDelta = Number(needsUserAction(b)) - Number(needsUserAction(a));
+        if (actionDelta !== 0) return actionDelta;
+        return Number(b.createtime) - Number(a.createtime);
+    });
 
     const ClaimsSection = ({
         title,
@@ -160,9 +213,12 @@ export default () => {
 
         return (
         <div className="mt-6 rounded-2xl border border-white/50 bg-white/75 p-4 shadow-sm backdrop-blur">
-            <div className="mb-3 flex items-center justify-between gap-2">
-                <p className={`text-xs font-bold uppercase tracking-[0.18em] ${accentClass}`}>{title}</p>
-                <div className="flex items-center gap-2">
+            <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                    <p className={`text-xs font-bold uppercase tracking-[0.18em] ${accentClass}`}>{title}</p>
+                    <p className="mt-1 text-xs text-slate-500">Open requests stay visible until they are resolved.</p>
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
                     {claims.length > 0 && (
                         <span className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide text-slate-600">
                             {claims.length}
@@ -213,31 +269,69 @@ export default () => {
 
     return (
         <>
-            <div className="mb-4 mt-1 rounded-2xl border border-white/50 bg-white/75 p-3 shadow-sm backdrop-blur">
-                <p className="mb-2 text-xs font-bold uppercase tracking-[0.18em] text-orange-700">Escrow Orders</p>
-                <div className="flex flex-wrap gap-2">
-                <button
-                    type="button"
-                    onClick={() => setOpenOrderForm(true)}
-                    className="btn-modern-primary commerce-gradient min-w-[160px] rounded-xl px-4 py-2 text-sm font-semibold text-white shadow-sm"
-                >
-                    Create An Order
-                </button>
-                <button
-                    type="button"
-                    onClick={loadAllOrders}
-                    className="btn-modern-secondary min-w-[160px] rounded-xl border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-orange-500 hover:text-orange-700"
-                >
-                    All Orders ({page})
-                </button>
+            <section className="mb-4 mt-1 rounded-3xl border border-white/50 bg-white/80 p-4 shadow-sm backdrop-blur sm:p-5">
+                <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+                    <div>
+                        <p className="text-xs font-bold uppercase tracking-[0.18em] text-orange-700">Order Action Center</p>
+                        <h1 className="mt-1 text-2xl font-extrabold tracking-tight text-slate-900">What needs your attention</h1>
+                        <p className="mt-1 text-sm text-slate-600">Vansday puts the next required action first and keeps protocol status in the background.</p>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                        <button
+                            type="button"
+                            onClick={() => setOpenOrderForm(true)}
+                            className="btn-modern-primary commerce-gradient rounded-xl px-4 py-2.5 text-sm font-semibold text-white shadow-sm"
+                        >
+                            Create Order
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => { loadProcessingOrders(); loadClaims(); }}
+                            disabled={loading || claimsLoading}
+                            className="btn-modern-secondary rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-700 transition hover:border-orange-500 hover:text-orange-700 disabled:opacity-50"
+                        >
+                            Refresh
+                        </button>
+                    </div>
                 </div>
-                <div className="mt-3 flex flex-wrap gap-1.5">
+
+                <div className="mt-4 grid grid-cols-1 gap-2 sm:grid-cols-3">
+                    <button
+                        type="button"
+                        onClick={() => setStatusFilter('action')}
+                        className={`rounded-2xl border p-3 text-left transition ${statusFilter === 'action' ? 'border-orange-400 bg-orange-50' : 'border-slate-200 bg-white hover:border-orange-300'}`}
+                    >
+                        <p className="text-xs font-semibold uppercase tracking-wide text-orange-700">Needs you</p>
+                        <p className="mt-1 text-2xl font-extrabold text-slate-900">{needsActionCount + openIncomingClaims}</p>
+                        <p className="mt-1 text-xs text-slate-500">Orders and incoming claims requiring action</p>
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => setStatusFilter('all')}
+                        className="rounded-2xl border border-slate-200 bg-white p-3 text-left transition hover:border-teal-300"
+                    >
+                        <p className="text-xs font-semibold uppercase tracking-wide text-teal-700">Waiting</p>
+                        <p className="mt-1 text-2xl font-extrabold text-slate-900">{waitingOrderCount + openBuyerClaims}</p>
+                        <p className="mt-1 text-xs text-slate-500">Waiting on the other party</p>
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => setStatusFilter(ORDER_STATUS_CLOSED)}
+                        className="rounded-2xl border border-slate-200 bg-white p-3 text-left transition hover:border-slate-400"
+                    >
+                        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Complete</p>
+                        <p className="mt-1 text-2xl font-extrabold text-slate-900">{completeOrderCount}</p>
+                        <p className="mt-1 text-xs text-slate-500">Loaded closed, canceled, or refunded orders</p>
+                    </button>
+                </div>
+
+                <div className="mt-4 flex flex-wrap gap-1.5">
                     {STATUS_FILTERS.map((f) => (
                         <button
                             key={f.value}
                             type="button"
                             onClick={() => setStatusFilter(f.value)}
-                            className={`rounded-full px-3 py-1 text-[11px] font-semibold transition ${
+                            className={`rounded-full px-3 py-1.5 text-[11px] font-semibold transition ${
                                 statusFilter === f.value
                                     ? 'bg-orange-500 text-white'
                                     : 'border border-slate-300 bg-white text-slate-600 hover:border-orange-400 hover:text-orange-700'
@@ -247,23 +341,49 @@ export default () => {
                         </button>
                     ))}
                 </div>
-            </div>
+            </section>
 
-            {!loading && (
+            {!loading && sortedOrders.length > 0 && (
                 <div className="space-y-3">
-                    {ol}
+                    {sortedOrders.map((order) => (
+                        <OrderListItem key={order.id.toString()} order={order} />
+                    ))}
+                </div>
+            )}
+
+            {!loading && sortedOrders.length === 0 && (
+                <div className="rounded-2xl border border-slate-200 bg-white/80 p-6 text-center shadow-sm">
+                    <p className="text-sm font-semibold text-slate-700">
+                        {statusFilter === 'action' ? 'Nothing needs your action right now.' : 'No orders match this filter.'}
+                    </p>
+                    <p className="mt-1 text-xs text-slate-500">
+                        {statusFilter === 'action' ? 'You’re caught up. Waiting orders and claims are still available below.' : 'Try another status or load older orders.'}
+                    </p>
                 </div>
             )}
 
             {loading && (
                 <div className="space-y-2">
-                    <div className="h-8 animate-pulse rounded bg-slate-200" />
-                    <div className="h-8 animate-pulse rounded bg-slate-100" />
+                    <div className="h-24 animate-pulse rounded-2xl bg-slate-200" />
+                    <div className="h-24 animate-pulse rounded-2xl bg-slate-100" />
+                </div>
+            )}
+
+            {hasOlderOrders && (
+                <div className="mt-4 flex justify-center">
+                    <button
+                        type="button"
+                        onClick={loadAllOrders}
+                        disabled={loading}
+                        className="btn-modern-secondary rounded-xl border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-orange-500 hover:text-orange-700 disabled:opacity-50"
+                    >
+                        Load Older Orders
+                    </button>
                 </div>
             )}
 
             <ClaimsSection
-                title="My Free Item Claims (as Buyer)"
+                title="My Free Item Claims"
                 accentClass="text-emerald-700"
                 claims={buyerClaims}
                 role="buyer"
@@ -271,7 +391,7 @@ export default () => {
             />
 
             <ClaimsSection
-                title="Incoming Claims on My Items (as Seller)"
+                title="Incoming Claims on My Items"
                 accentClass="text-blue-700"
                 claims={sellerClaims}
                 role="seller"
@@ -285,10 +405,12 @@ export default () => {
                             type="button"
                             onClick={() => setOpenOrderForm(false)}
                             className="absolute right-3 top-3 h-8 w-8 rounded-full text-slate-500 transition hover:bg-slate-100"
+                            aria-label="Close order form"
                         >
-                            x
+                            ×
                         </button>
-                        <h3 className="mb-4 text-lg font-semibold text-slate-900">New Escrow Contract</h3>
+                        <h3 className="mb-1 text-lg font-semibold text-slate-900">New Escrow Contract</h3>
+                        <p className="mb-4 text-sm text-slate-500">Create the agreement, then Vansday will guide each participant through the next action.</p>
                         <OrderForm buy={buy} sell={sell} />
                     </div>
                 </div>

--- a/frontend/components/orders/OrderList.tsx
+++ b/frontend/components/orders/OrderList.tsx
@@ -22,10 +22,10 @@ const PAGE_SIZE = 20;
 export default () => {
     const escrow = useEscrow();
     const { state: { principal } } = useGlobalContext();
-    const [orders, setOrders] = React.useState<any[]>([])
-    const [loading, setLoading] = React.useState(false)
-    const [page, setPage] = React.useState(1)
-    const [hasOlderOrders, setHasOlderOrders] = React.useState(true)
+    const [orders, setOrders] = React.useState<any[]>([]);
+    const [loading, setLoading] = React.useState(false);
+    const [page, setPage] = React.useState(1);
+    const [hasOlderOrders, setHasOlderOrders] = React.useState(true);
 
     const [buyerClaims, setBuyerClaims] = React.useState<any[]>([]);
     const [sellerClaims, setSellerClaims] = React.useState<any[]>([]);
@@ -56,6 +56,10 @@ export default () => {
             || status === ORDER_STATUS_REFUNDED;
     }, [getStatus]);
 
+    const isCompletedOrder = React.useCallback((order: any) => {
+        return getStatus(order) === ORDER_STATUS_RELEASED || isTerminalOrder(order);
+    }, [getStatus, isTerminalOrder]);
+
     const needsUserAction = React.useCallback((order: any) => {
         if (!principal || order.amount === BigInt(0)) return false;
         const status = getStatus(order);
@@ -65,9 +69,17 @@ export default () => {
         return (status === ORDER_STATUS_NEW && isBuyer)
             || (status === ORDER_STATUS_DEPOSITED && isSeller)
             || (status === ORDER_STATUS_DELIVERED && isBuyer)
-            || (status === ORDER_STATUS_RECEIVED && isSeller)
-            || (status === ORDER_STATUS_RELEASED && isSeller);
+            || (status === ORDER_STATUS_RECEIVED && isSeller);
     }, [getStatus, principal]);
+
+    const isWaitingOrder = React.useCallback((order: any) => {
+        if (isCompletedOrder(order) || needsUserAction(order)) return false;
+        const status = getStatus(order);
+        return status === ORDER_STATUS_NEW
+            || status === ORDER_STATUS_DEPOSITED
+            || status === ORDER_STATUS_DELIVERED
+            || status === ORDER_STATUS_RECEIVED;
+    }, [getStatus, isCompletedOrder, needsUserAction]);
 
     const isClaimResolved = React.useCallback((claim: any): boolean => {
         const isOptSet = (v: any) => v !== null && v !== undefined && (!Array.isArray(v) || v.length > 0);
@@ -76,28 +88,28 @@ export default () => {
 
     React.useEffect(() => {
         if (!principal) return;
-        setPage(1);
-        setHasOlderOrders(true);
         loadProcessingOrders();
         loadClaims();
     }, [principal]);
 
     async function loadProcessingOrders() {
         if (!principal) return;
-        setLoading(true)
+        setLoading(true);
         try {
             const os = await escrow.getOrders();
-            setOrders(os)
+            setOrders(os);
+            setPage(1);
+            setHasOlderOrders(true);
         } catch (err) {
             toast.error(err?.toString() ?? 'Failed to load orders');
         } finally {
-            setLoading(false)
+            setLoading(false);
         }
-    };
+    }
 
     async function loadAllOrders() {
         if (!principal) return;
-        setLoading(true)
+        setLoading(true);
         try {
             const os = await escrow.getAllOrders(BigInt(page));
             setOrders((previous) => {
@@ -105,14 +117,14 @@ export default () => {
                 os.forEach((order: any) => byId.set(order.id.toString(), order));
                 return Array.from(byId.values());
             });
-            setPage((current) => current + 1)
-            setHasOlderOrders(os.length === PAGE_SIZE)
+            setPage((current) => current + 1);
+            setHasOlderOrders(os.length === PAGE_SIZE);
         } catch (err) {
             toast.error(err?.toString() ?? 'Failed to load older orders');
         } finally {
-            setLoading(false)
+            setLoading(false);
         }
-    };
+    }
 
     function loadClaims() {
         if (!principal) return;
@@ -143,43 +155,51 @@ export default () => {
         setSellerClaims((prev) => prev.map((c) => (c.id === updated.id ? updated : c)));
     };
 
+    const updateOrderStatus = React.useCallback((orderId: bigint, nextStatus: string) => {
+        setOrders((previous) => previous.map((order) =>
+            order.id === orderId
+                ? { ...order, status: { [nextStatus]: null } }
+                : order,
+        ));
+    }, []);
+
     async function buy(newOrder: NewOrder) {
-        setLoading(true)
+        setLoading(true);
         try {
             const res = await escrow.buy(newOrder);
-            if (res["ok"] !== undefined) {
-                toast.success("Order created. Next action is shown below.")
-                setOpenOrderForm(false)
-                setStatusFilter('action')
-                await loadProcessingOrders()
+            if (res['ok'] !== undefined) {
+                toast.success('Order created. Next action is shown below.');
+                setOpenOrderForm(false);
+                setStatusFilter('action');
+                await loadProcessingOrders();
             } else {
-                toast.error(res["err"]?.toString() ?? 'Failed to create order');
+                toast.error(res['err']?.toString() ?? 'Failed to create order');
             }
         } catch (err) {
-            toast.error(err?.toString() ?? 'Failed to create order')
+            toast.error(err?.toString() ?? 'Failed to create order');
         } finally {
-            setLoading(false)
+            setLoading(false);
         }
-    };
+    }
 
     async function sell(newOrder: NewSellOrder) {
-        setLoading(true)
+        setLoading(true);
         try {
             const res = await escrow.sell(newOrder);
-            if (res["ok"] !== undefined) {
-                toast.success("Order created. Next action is shown below.")
-                setOpenOrderForm(false)
-                setStatusFilter('action')
-                await loadProcessingOrders()
+            if (res['ok'] !== undefined) {
+                toast.success('Order created. Next action is shown below.');
+                setOpenOrderForm(false);
+                setStatusFilter('action');
+                await loadProcessingOrders();
             } else {
-                toast.error(res["err"]?.toString() ?? 'Failed to create order');
+                toast.error(res['err']?.toString() ?? 'Failed to create order');
             }
         } catch (err) {
-            toast.error(err?.toString() ?? 'Failed to create order')
+            toast.error(err?.toString() ?? 'Failed to create order');
         } finally {
-            setLoading(false)
+            setLoading(false);
         }
-    };
+    }
 
     if (!principal) {
         return (
@@ -192,17 +212,18 @@ export default () => {
     }
 
     const needsActionCount = orders.filter(needsUserAction).length;
-    const openOrderCount = orders.filter((order) => !isTerminalOrder(order)).length;
-    const waitingOrderCount = Math.max(0, openOrderCount - needsActionCount);
-    const completeOrderCount = orders.filter(isTerminalOrder).length;
+    const waitingOrderCount = orders.filter(isWaitingOrder).length;
+    const completeOrderCount = orders.filter(isCompletedOrder).length;
 
     const filteredOrders = statusFilter === 'action'
         ? orders.filter(needsUserAction)
-        : statusFilter === 'complete'
-            ? orders.filter(isTerminalOrder)
-            : statusFilter === 'all'
-                ? orders
-                : orders.filter((o: any) => getStatus(o) === statusFilter);
+        : statusFilter === 'waiting'
+            ? orders.filter(isWaitingOrder)
+            : statusFilter === 'complete'
+                ? orders.filter(isCompletedOrder)
+                : statusFilter === 'all'
+                    ? orders
+                    : orders.filter((order: any) => getStatus(order) === statusFilter);
 
     const sortedOrders = [...filteredOrders].sort((a: any, b: any) => {
         const actionDelta = Number(needsUserAction(b)) - Number(needsUserAction(a));
@@ -225,61 +246,61 @@ export default () => {
     }) => {
         const [showClosed, setShowClosed] = React.useState(false);
         const closedCount = claims.filter(isClaimResolved).length;
-        const visibleClaims = showClosed ? claims : claims.filter((c) => !isClaimResolved(c));
+        const visibleClaims = showClosed ? claims : claims.filter((claim) => !isClaimResolved(claim));
 
         return (
-        <div className="mt-6 rounded-2xl border border-white/50 bg-white/75 p-4 shadow-sm backdrop-blur">
-            <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                <div>
-                    <p className={`text-xs font-bold uppercase tracking-[0.18em] ${accentClass}`}>{title}</p>
-                    <p className="mt-1 text-xs text-slate-500">Open requests stay visible until they are resolved.</p>
-                </div>
-                <div className="flex flex-wrap items-center gap-2">
-                    {claims.length > 0 && (
-                        <span className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide text-slate-600">
-                            {claims.length}
-                        </span>
-                    )}
-                    {closedCount > 0 && (
+            <div className="mt-6 rounded-2xl border border-white/50 bg-white/75 p-4 shadow-sm backdrop-blur">
+                <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                        <p className={`text-xs font-bold uppercase tracking-[0.18em] ${accentClass}`}>{title}</p>
+                        <p className="mt-1 text-xs text-slate-500">Open requests stay visible until they are resolved.</p>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                        {claims.length > 0 && (
+                            <span className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide text-slate-600">
+                                {claims.length}
+                            </span>
+                        )}
+                        {closedCount > 0 && (
+                            <button
+                                type="button"
+                                onClick={() => setShowClosed((value) => !value)}
+                                className="rounded-lg border border-slate-300 bg-white px-2.5 py-1 text-[11px] font-semibold text-slate-600 transition hover:border-orange-400 hover:text-orange-700"
+                            >
+                                {showClosed ? 'Hide closed' : `Show closed (${closedCount})`}
+                            </button>
+                        )}
                         <button
                             type="button"
-                            onClick={() => setShowClosed((v) => !v)}
-                            className="rounded-lg border border-slate-300 bg-white px-2.5 py-1 text-[11px] font-semibold text-slate-600 transition hover:border-orange-400 hover:text-orange-700"
+                            onClick={loadClaims}
+                            disabled={claimsLoading}
+                            className="rounded-lg border border-slate-300 bg-white px-2.5 py-1 text-[11px] font-semibold text-slate-600 transition hover:border-orange-400 hover:text-orange-700 disabled:opacity-40"
                         >
-                            {showClosed ? 'Hide closed' : `Show closed (${closedCount})`}
+                            Refresh
                         </button>
-                    )}
-                    <button
-                        type="button"
-                        onClick={loadClaims}
-                        disabled={claimsLoading}
-                        className="rounded-lg border border-slate-300 bg-white px-2.5 py-1 text-[11px] font-semibold text-slate-600 transition hover:border-orange-400 hover:text-orange-700 disabled:opacity-40"
-                    >
-                        Refresh
-                    </button>
+                    </div>
                 </div>
+                {claimsLoading && (
+                    <div className="h-8 animate-pulse rounded bg-slate-200" />
+                )}
+                {!claimsLoading && visibleClaims.length === 0 && (
+                    <p className="text-sm text-slate-500">
+                        {claims.length === 0 ? 'No claims here yet.' : 'No open claims. Use "Show closed" to view resolved claims.'}
+                    </p>
+                )}
+                {!claimsLoading && visibleClaims.length > 0 && (
+                    <div className="space-y-2">
+                        {visibleClaims.map((claim) => (
+                            <ClaimCard
+                                key={String(claim.id)}
+                                claim={claim}
+                                role={role}
+                                onUpdated={onUpdated}
+                            />
+                        ))}
+                    </div>
+                )}
             </div>
-            {claimsLoading && (
-                <div className="h-8 animate-pulse rounded bg-slate-200" />
-            )}
-            {!claimsLoading && visibleClaims.length === 0 && (
-                <p className="text-sm text-slate-500">
-                    {claims.length === 0 ? 'No claims here yet.' : 'No open claims. Use "Show closed" to view resolved claims.'}
-                </p>
-            )}
-            {!claimsLoading && visibleClaims.length > 0 && (
-                <div className="space-y-2">
-                    {visibleClaims.map((claim) => (
-                        <ClaimCard
-                            key={String(claim.id)}
-                            claim={claim}
-                            role={role}
-                            onUpdated={onUpdated}
-                        />
-                    ))}
-                </div>
-            )}
-        </div>
         );
     };
 
@@ -323,8 +344,8 @@ export default () => {
                     </button>
                     <button
                         type="button"
-                        onClick={() => setStatusFilter('all')}
-                        className="rounded-2xl border border-slate-200 bg-white p-3 text-left transition hover:border-teal-300"
+                        onClick={() => setStatusFilter('waiting')}
+                        className={`rounded-2xl border p-3 text-left transition ${statusFilter === 'waiting' ? 'border-teal-400 bg-teal-50' : 'border-slate-200 bg-white hover:border-teal-300'}`}
                     >
                         <p className="text-xs font-semibold uppercase tracking-wide text-teal-700">Waiting</p>
                         <p className="mt-1 text-2xl font-extrabold text-slate-900">{waitingOrderCount}</p>
@@ -337,23 +358,23 @@ export default () => {
                     >
                         <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Complete</p>
                         <p className="mt-1 text-2xl font-extrabold text-slate-900">{completeOrderCount}</p>
-                        <p className="mt-1 text-xs text-slate-500">Loaded closed, canceled, or refunded orders</p>
+                        <p className="mt-1 text-xs text-slate-500">Released, closed, canceled, or refunded orders</p>
                     </button>
                 </div>
 
                 <div className="mt-4 flex flex-wrap gap-1.5">
-                    {STATUS_FILTERS.map((f) => (
+                    {STATUS_FILTERS.map((filter) => (
                         <button
-                            key={f.value}
+                            key={filter.value}
                             type="button"
-                            onClick={() => setStatusFilter(f.value)}
+                            onClick={() => setStatusFilter(filter.value)}
                             className={`rounded-full px-3 py-1.5 text-[11px] font-semibold transition ${
-                                statusFilter === f.value
+                                statusFilter === filter.value
                                     ? 'bg-orange-500 text-white'
                                     : 'border border-slate-300 bg-white text-slate-600 hover:border-orange-400 hover:text-orange-700'
                             }`}
                         >
-                            {f.label}
+                            {filter.label}
                         </button>
                     ))}
                 </div>
@@ -362,7 +383,11 @@ export default () => {
             {!loading && sortedOrders.length > 0 && (
                 <div className="space-y-3">
                     {sortedOrders.map((order) => (
-                        <OrderListItem key={order.id.toString()} order={order} />
+                        <OrderListItem
+                            key={order.id.toString()}
+                            order={order}
+                            onStatusChange={updateOrderStatus}
+                        />
                     ))}
                 </div>
             )}
@@ -370,10 +395,16 @@ export default () => {
             {!loading && sortedOrders.length === 0 && (
                 <div className="rounded-2xl border border-slate-200 bg-white/80 p-6 text-center shadow-sm">
                     <p className="text-sm font-semibold text-slate-700">
-                        {statusFilter === 'action' ? 'Nothing needs your action right now.' : 'No orders match this filter.'}
+                        {statusFilter === 'action'
+                            ? 'Nothing needs your action right now.'
+                            : statusFilter === 'waiting'
+                                ? 'No orders are waiting on the other party.'
+                                : 'No orders match this filter.'}
                     </p>
                     <p className="mt-1 text-xs text-slate-500">
-                        {statusFilter === 'action' ? 'You’re caught up. Waiting orders and claims are still available below.' : 'Try another status or load older orders.'}
+                        {statusFilter === 'action'
+                            ? 'You’re caught up. Waiting and completed orders are available from the summary above.'
+                            : 'Try another status or load older orders.'}
                     </p>
                 </div>
             )}
@@ -416,7 +447,7 @@ export default () => {
 
             {openOrderForm && (
                 <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" onClick={() => setOpenOrderForm(false)}>
-                    <div className="relative max-h-[90vh] w-full max-w-3xl overflow-auto rounded-2xl border border-white/40 bg-white/95 p-4 shadow-2xl" onClick={(e) => e.stopPropagation()}>
+                    <div className="relative max-h-[90vh] w-full max-w-3xl overflow-auto rounded-2xl border border-white/40 bg-white/95 p-4 shadow-2xl" onClick={(event) => event.stopPropagation()}>
                         <button
                             type="button"
                             onClick={() => setOpenOrderForm(false)}
@@ -432,5 +463,5 @@ export default () => {
                 </div>
             )}
         </>
-    )
+    );
 }

--- a/frontend/components/orders/OrderList.tsx
+++ b/frontend/components/orders/OrderList.tsx
@@ -195,14 +195,14 @@ export default () => {
     const openOrderCount = orders.filter((order) => !isTerminalOrder(order)).length;
     const waitingOrderCount = Math.max(0, openOrderCount - needsActionCount);
     const completeOrderCount = orders.filter(isTerminalOrder).length;
-    const openIncomingClaims = sellerClaims.filter((claim) => !isClaimResolved(claim)).length;
-    const openBuyerClaims = buyerClaims.filter((claim) => !isClaimResolved(claim)).length;
 
     const filteredOrders = statusFilter === 'action'
         ? orders.filter(needsUserAction)
-        : statusFilter === 'all'
-            ? orders
-            : orders.filter((o: any) => getStatus(o) === statusFilter);
+        : statusFilter === 'complete'
+            ? orders.filter(isTerminalOrder)
+            : statusFilter === 'all'
+                ? orders
+                : orders.filter((o: any) => getStatus(o) === statusFilter);
 
     const sortedOrders = [...filteredOrders].sort((a: any, b: any) => {
         const actionDelta = Number(needsUserAction(b)) - Number(needsUserAction(a));
@@ -318,8 +318,8 @@ export default () => {
                         className={`rounded-2xl border p-3 text-left transition ${statusFilter === 'action' ? 'border-orange-400 bg-orange-50' : 'border-slate-200 bg-white hover:border-orange-300'}`}
                     >
                         <p className="text-xs font-semibold uppercase tracking-wide text-orange-700">Needs you</p>
-                        <p className="mt-1 text-2xl font-extrabold text-slate-900">{needsActionCount + openIncomingClaims}</p>
-                        <p className="mt-1 text-xs text-slate-500">Orders and incoming claims requiring action</p>
+                        <p className="mt-1 text-2xl font-extrabold text-slate-900">{needsActionCount}</p>
+                        <p className="mt-1 text-xs text-slate-500">Orders requiring your next action</p>
                     </button>
                     <button
                         type="button"
@@ -327,13 +327,13 @@ export default () => {
                         className="rounded-2xl border border-slate-200 bg-white p-3 text-left transition hover:border-teal-300"
                     >
                         <p className="text-xs font-semibold uppercase tracking-wide text-teal-700">Waiting</p>
-                        <p className="mt-1 text-2xl font-extrabold text-slate-900">{waitingOrderCount + openBuyerClaims}</p>
-                        <p className="mt-1 text-xs text-slate-500">Waiting on the other party</p>
+                        <p className="mt-1 text-2xl font-extrabold text-slate-900">{waitingOrderCount}</p>
+                        <p className="mt-1 text-xs text-slate-500">Open orders waiting on the other party</p>
                     </button>
                     <button
                         type="button"
-                        onClick={() => setStatusFilter(ORDER_STATUS_CLOSED)}
-                        className="rounded-2xl border border-slate-200 bg-white p-3 text-left transition hover:border-slate-400"
+                        onClick={() => setStatusFilter('complete')}
+                        className={`rounded-2xl border p-3 text-left transition ${statusFilter === 'complete' ? 'border-slate-400 bg-slate-100' : 'border-slate-200 bg-white hover:border-slate-400'}`}
                     >
                         <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Complete</p>
                         <p className="mt-1 text-2xl font-extrabold text-slate-900">{completeOrderCount}</p>

--- a/frontend/components/orders/OrderListItem.tsx
+++ b/frontend/components/orders/OrderListItem.tsx
@@ -52,12 +52,31 @@ export default (props) => {
         (status === ORDER_STATUS_DEPOSITED && isSeller) ||
         (status === ORDER_STATUS_DELIVERED && isBuyer);
 
+    const needsAction = !isFreeOrder && (
+        needsConfirm ||
+        (status === ORDER_STATUS_RECEIVED && isSeller) ||
+        (status === ORDER_STATUS_RELEASED && isSeller)
+    );
+
+    const confirmationText = (() => {
+        if (status === ORDER_STATUS_NEW && isBuyer) {
+            return `I’m ready to deposit ${amount} ${currency} into escrow.`;
+        }
+        if (status === ORDER_STATUS_DEPOSITED && isSeller) {
+            return `I have delivered “${props.order.memo}” to the buyer.`;
+        }
+        if (status === ORDER_STATUS_DELIVERED && isBuyer) {
+            return `I received “${props.order.memo}” and understand this confirmation allows the seller to request payout.`;
+        }
+        return '';
+    })();
+
     async function act(fn: () => Promise<any>, nextStatus: string) {
         setBusy(true);
         try {
             const res = await fn();
             if (res['ok'] !== undefined) {
-                toast.success('Status updated');
+                toast.success('Order updated');
                 setStatus(nextStatus);
                 setConfirmed(false);
             } else {
@@ -95,11 +114,10 @@ export default (props) => {
 
     return (
         <>
-            <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-                {/* Header */}
+            <div className={`rounded-xl border bg-white p-4 shadow-sm ${needsAction ? 'border-orange-300 ring-1 ring-orange-100' : 'border-slate-200'}`}>
                 <div className="mb-3 flex items-start justify-between gap-3">
                     <div className="min-w-0">
-                        <div className="flex items-center gap-2">
+                        <div className="flex flex-wrap items-center gap-2">
                             <button
                                 type="button"
                                 onClick={() => setOpenOrder(true)}
@@ -110,80 +128,84 @@ export default (props) => {
                             <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide ${statusColor}`}>
                                 {status}
                             </span>
+                            {needsAction && (
+                                <span className="rounded-full bg-orange-500 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-white">
+                                    Action required
+                                </span>
+                            )}
                         </div>
-                        <p className="mt-1 text-base font-semibold text-slate-900 truncate">{props.order.memo}</p>
+                        <p className="mt-1 truncate text-base font-semibold text-slate-900">{props.order.memo}</p>
                     </div>
                     <span className="flex-shrink-0 rounded-full border border-teal-600/50 bg-teal-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-teal-700">
                         {isFreeOrder ? 'FREE' : `${amount} ${currency}`}
                     </span>
                 </div>
 
-                {/* Meta */}
                 <p className="mb-3 text-xs text-slate-500">
-                    {isBuyer ? 'You are buyer' : 'You are seller'} · {moment.unix(parseInt(props.order.createtime) / 1_000_000_000).format('YYYY-MM-DD HH:mm')}
+                    {isBuyer ? 'You are buyer' : isSeller ? 'You are seller' : 'Participant'} · {moment.unix(parseInt(props.order.createtime) / 1_000_000_000).format('YYYY-MM-DD HH:mm')}
                 </p>
 
-                {/* Hint */}
                 {!isFreeOrder && !isTerminal && (() => {
-                    if (status === ORDER_STATUS_NEW && isBuyer) return <p className="mb-2 rounded-md border border-sky-200 bg-sky-50 px-3 py-2 text-xs text-sky-800">Deposit {amount} {currency} to escrow account to proceed.</p>;
-                    if (status === ORDER_STATUS_NEW && isSeller) return <p className="mb-2 rounded-md border border-sky-200 bg-sky-50 px-3 py-2 text-xs text-sky-800">Waiting for buyer to deposit funds.</p>;
-                    if (status === ORDER_STATUS_DEPOSITED && isSeller) return <p className="mb-2 rounded-md border border-sky-200 bg-sky-50 px-3 py-2 text-xs text-sky-800">Confirm delivery of "{props.order.memo}" to buyer.</p>;
-                    if (status === ORDER_STATUS_DEPOSITED && isBuyer) return <p className="mb-2 rounded-md border border-sky-200 bg-sky-50 px-3 py-2 text-xs text-sky-800">Waiting for seller to deliver.</p>;
-                    if (status === ORDER_STATUS_DELIVERED && isBuyer) return <p className="mb-2 rounded-md border border-sky-200 bg-sky-50 px-3 py-2 text-xs text-sky-800">Confirm receipt — this releases funds to the seller.</p>;
-                    if (status === ORDER_STATUS_RECEIVED && isSeller) return <p className="mb-2 rounded-md border border-sky-200 bg-sky-50 px-3 py-2 text-xs text-sky-800">Request fund release (transaction fee applies).</p>;
+                    if (status === ORDER_STATUS_NEW && isBuyer) return <p className="mb-2 rounded-md border border-sky-200 bg-sky-50 px-3 py-2 text-xs text-sky-800">Next: deposit {amount} {currency} into escrow to fund this order.</p>;
+                    if (status === ORDER_STATUS_NEW && isSeller) return <p className="mb-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-700">Waiting for the buyer to fund escrow.</p>;
+                    if (status === ORDER_STATUS_DEPOSITED && isSeller) return <p className="mb-2 rounded-md border border-sky-200 bg-sky-50 px-3 py-2 text-xs text-sky-800">Next: deliver “{props.order.memo}”, then confirm delivery here.</p>;
+                    if (status === ORDER_STATUS_DEPOSITED && isBuyer) return <p className="mb-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-700">Escrow is funded. Waiting for the seller to deliver.</p>;
+                    if (status === ORDER_STATUS_DELIVERED && isBuyer) return <p className="mb-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">Next: confirm receipt only after you have received the item or service.</p>;
+                    if (status === ORDER_STATUS_DELIVERED && isSeller) return <p className="mb-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-700">Waiting for the buyer to confirm receipt.</p>;
+                    if (status === ORDER_STATUS_RECEIVED && isSeller) return <p className="mb-2 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-800">Buyer confirmed receipt. You can now request release of the escrowed funds.</p>;
+                    if (status === ORDER_STATUS_RECEIVED && isBuyer) return <p className="mb-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-700">Receipt confirmed. Waiting for the seller to request payout.</p>;
+                    if (status === ORDER_STATUS_RELEASED && isSeller) return <p className="mb-2 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-800">Funds were released. Close the order when everything is complete.</p>;
                     return null;
                 })()}
 
-                {/* Confirm checkbox */}
                 {needsConfirm && !isFreeOrder && (
-                    <label className="mb-2 inline-flex items-center gap-2 text-sm text-slate-700 select-none">
-                        <input type="checkbox" checked={confirmed} onChange={e => setConfirmed(e.target.checked)} />
-                        YES, I confirmed
+                    <label className="mb-3 flex items-start gap-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-700 select-none">
+                        <input className="mt-0.5" type="checkbox" checked={confirmed} onChange={e => setConfirmed(e.target.checked)} />
+                        <span>{confirmationText}</span>
                     </label>
                 )}
 
-                {/* Actions */}
                 {!isTerminal && (
                     <div className="flex flex-wrap gap-2">
                         {!isFreeOrder && status === ORDER_STATUS_NEW && isBuyer && (
                             <button disabled={!confirmed || busy} onClick={() => act(() => escrow.deposit(props.order.id), ORDER_STATUS_DEPOSITED)}
                                 className="rounded-md bg-cyan-600 px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-cyan-700 disabled:cursor-not-allowed disabled:bg-slate-300">
-                                Deposit
+                                Deposit to Escrow
                             </button>
                         )}
                         {!isFreeOrder && status === ORDER_STATUS_DEPOSITED && isSeller && (
                             <button disabled={!confirmed || busy} onClick={() => act(() => escrow.deliver(props.order.id), ORDER_STATUS_DELIVERED)}
                                 className="rounded-md bg-cyan-600 px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-cyan-700 disabled:cursor-not-allowed disabled:bg-slate-300">
-                                Deliver
+                                Confirm Delivery
                             </button>
                         )}
                         {!isFreeOrder && status === ORDER_STATUS_DELIVERED && isBuyer && (
                             <button disabled={!confirmed || busy} onClick={() => act(() => escrow.receive(props.order.id), ORDER_STATUS_RECEIVED)}
                                 className="rounded-md bg-cyan-600 px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-cyan-700 disabled:cursor-not-allowed disabled:bg-slate-300">
-                                Receive
+                                Confirm Receipt
                             </button>
                         )}
                         {!isFreeOrder && status === ORDER_STATUS_RECEIVED && isSeller && (
                             <button disabled={busy} onClick={() => act(() => escrow.release(props.order.id), ORDER_STATUS_RELEASED)}
                                 className="rounded-md bg-cyan-600 px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-cyan-700 disabled:cursor-not-allowed disabled:bg-slate-300">
-                                Release Fund
+                                Release Funds
                             </button>
                         )}
                         {!isFreeOrder && status === ORDER_STATUS_NEW && (
                             <button disabled={busy} onClick={() => act(() => escrow.cancel(props.order.id), ORDER_STATUS_CANCELED)}
                                 className="rounded-md border border-rose-400 px-3 py-1.5 text-sm font-semibold text-rose-600 transition hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-50">
-                                Cancel
+                                Cancel Order
                             </button>
                         )}
-                        {isSeller && (
+                        {isSeller && (isFreeOrder || status === ORDER_STATUS_RELEASED) && (
                             <button disabled={busy} onClick={() => act(() => escrow.close(props.order.id), ORDER_STATUS_CLOSED)}
                                 className="rounded-md border border-slate-400 px-3 py-1.5 text-sm font-semibold text-slate-600 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50">
-                                Close
+                                Close Order
                             </button>
                         )}
                         <button type="button" onClick={() => setShowComment(v => !v)}
                             className="rounded-md border border-slate-300 px-3 py-1.5 text-sm font-semibold text-slate-600 transition hover:bg-slate-50">
-                            {showComment ? 'Cancel' : 'Comment'}
+                            {showComment ? 'Cancel Comment' : 'Comment'}
                         </button>
                     </div>
                 )}
@@ -196,7 +218,7 @@ export default (props) => {
                         </button>
                         <button type="button" onClick={() => setShowComment(v => !v)}
                             className="rounded-md border border-slate-300 px-3 py-1.5 text-sm font-semibold text-slate-600 transition hover:bg-slate-50">
-                            {showComment ? 'Cancel' : 'Comment'}
+                            {showComment ? 'Cancel Comment' : 'Comment'}
                         </button>
                     </div>
                 )}
@@ -230,12 +252,13 @@ export default (props) => {
 
             {openOrder && (
                 <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" onClick={() => setOpenOrder(false)}>
-                    <div className="relative max-h-[90vh] w-full max-w-3xl overflow-auto rounded-lg bg-white p-4" onClick={(e) => e.stopPropagation()}>
+                    <div className="relative max-h-[90vh] w-full max-w-3xl overflow-auto rounded-2xl bg-white p-4 shadow-2xl" onClick={(e) => e.stopPropagation()}>
                         <button type="button" onClick={() => setOpenOrder(false)}
-                            className="absolute right-3 top-3 h-8 w-8 rounded-full text-slate-500 transition hover:bg-slate-100">
+                            className="absolute right-3 top-3 h-8 w-8 rounded-full text-slate-500 transition hover:bg-slate-100"
+                            aria-label="Close order details">
                             ✕
                         </button>
-                        <h3 className="mb-4 text-lg font-semibold text-slate-900">Order: {props.order.memo}</h3>
+                        <h3 className="mb-4 pr-10 text-lg font-semibold text-slate-900">Order: {props.order.memo}</h3>
                         <OrderDetail order={props.order} />
                     </div>
                 </div>

--- a/frontend/components/orders/OrderListItem.tsx
+++ b/frontend/components/orders/OrderListItem.tsx
@@ -39,6 +39,10 @@ export default (props) => {
     const [commentText, setCommentText] = React.useState('');
     const [comments, setComments] = React.useState<any[]>(props.order.comments ?? []);
 
+    React.useEffect(() => {
+        setStatus(Object.getOwnPropertyNames(props.order.status)[0]);
+    }, [props.order.status]);
+
     const currency = currencySymbol(props.order.currency);
     const es = currencyBase(props.order.currency);
     const amount = parseInt(props.order.amount) / es;
@@ -54,8 +58,7 @@ export default (props) => {
 
     const needsAction = !isFreeOrder && (
         needsConfirm ||
-        (status === ORDER_STATUS_RECEIVED && isSeller) ||
-        (status === ORDER_STATUS_RELEASED && isSeller)
+        (status === ORDER_STATUS_RECEIVED && isSeller)
     );
 
     const confirmationText = (() => {
@@ -79,6 +82,7 @@ export default (props) => {
                 toast.success('Order updated');
                 setStatus(nextStatus);
                 setConfirmed(false);
+                props.onStatusChange?.(props.order.id, nextStatus);
             } else {
                 toast.error(res['err'] ?? 'Action failed');
             }
@@ -154,7 +158,7 @@ export default (props) => {
                     if (status === ORDER_STATUS_DELIVERED && isSeller) return <p className="mb-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-700">Waiting for the buyer to confirm receipt.</p>;
                     if (status === ORDER_STATUS_RECEIVED && isSeller) return <p className="mb-2 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-800">Buyer confirmed receipt. You can now request release of the escrowed funds.</p>;
                     if (status === ORDER_STATUS_RECEIVED && isBuyer) return <p className="mb-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-700">Receipt confirmed. Waiting for the seller to request payout.</p>;
-                    if (status === ORDER_STATUS_RELEASED && isSeller) return <p className="mb-2 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-800">Funds were released. Close the order when everything is complete.</p>;
+                    if (status === ORDER_STATUS_RELEASED) return <p className="mb-2 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-800">Funds released. The financial flow is complete; closing this order is optional archival cleanup.</p>;
                     return null;
                 })()}
 
@@ -259,7 +263,7 @@ export default (props) => {
                             ✕
                         </button>
                         <h3 className="mb-4 pr-10 text-lg font-semibold text-slate-900">Order: {props.order.memo}</h3>
-                        <OrderDetail order={props.order} />
+                        <OrderDetail order={{ ...props.order, status: { [status]: null } }} />
                     </div>
                 </div>
             )}

--- a/frontend/header/index.tsx
+++ b/frontend/header/index.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useState } from 'react'
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import vansdayLogo from '../assets/vansday.png'
 import DarkModeToggle from './DarkModeToggle'
 
@@ -8,9 +8,8 @@ import { useEffect } from "react"
 import { HttpAgent, Identity } from "@dfinity/agent";
 import { AuthClient } from "@dfinity/auth-client";
 import { HOST } from "../lib/canisters";
-import { MENU_ORDERS, MENU_PROFILE, MENU_HOME, MENU_FREE, MENU_MY_ITEMS } from "../lib/constants";
 
-import { useSetAgent, useGlobalContext, useLoading, useMenu } from "../components/Store";
+import { useSetAgent, useGlobalContext, useLoading } from "../components/Store";
 
 import LoginButton from "../components/LoginButton";
 import NotificationBell from "../components/NotificationBell";
@@ -18,76 +17,50 @@ import PrincipalName from "../components/PrincipalName";
 
 const Header: FC = () => {
   const setAgent = useSetAgent();
-
   const navigate = useNavigate();
-  const { menu, setMenu } = useMenu()
+  const location = useLocation();
   const { state: { isAuthed, principal } } = useGlobalContext();
-
   const { loading } = useLoading();
 
   const [authClient, setAuthClient] = useState<AuthClient>(null);
-
   const [openMenu, setOpenMenu] = React.useState(false);
+
   const handleClick = () => {
     setOpenMenu((prev) => !prev);
   };
+
   const handleClose = () => {
     setOpenMenu(false);
   };
 
-  const openOrders = () => {
+  const go = (path: string) => {
     handleClose();
-    setMenu(MENU_ORDERS)
-    navigate("/", { replace: true });
-  }
+    navigate(path);
+  };
 
-  const openProfile = () => {
-    handleClose();
-    setMenu(MENU_PROFILE)
-    navigate("/", { replace: true });
-  }
+  const openOrders = () => go('/orders');
+  const openProfile = () => go('/profile');
+  const openShop = () => go('/market');
+  const openFreeItems = () => go('/free');
+  const openMyItems = () => go('/items');
 
-  const openShop = () => {
-    setMenu(MENU_HOME);
-    navigate("/", { replace: true });
-  }
-
-  const openFreeItems = () => {
-    setMenu(MENU_FREE);
-    navigate("/", { replace: true });
-  }
-
-  const openMyItems = () => {
-    handleClose();
-    setMenu(MENU_MY_ITEMS);
-    navigate("/", { replace: true });
-  }
   useEffect(() => {
-    if (!menu) setMenu(MENU_HOME);
-
     (async () => {
-      const authClient = await AuthClient.create(
-        {
-          idleOptions: {
-            disableIdle: true,
-            disableDefaultIdleCallback: true
-          }
+      const authClient = await AuthClient.create({
+        idleOptions: {
+          disableIdle: true,
+          disableDefaultIdleCallback: true
         }
-      );
+      });
       setAuthClient(authClient);
 
       if (await authClient.isAuthenticated()) {
         handleAuthenticated(authClient);
-
       }
-
-
     })();
-
   }, []);
 
   const handleAuthenticated = async (authClient: AuthClient) => {
-
     const identity: Identity = authClient.getIdentity();
 
     setAgent({
@@ -96,19 +69,36 @@ const Header: FC = () => {
         host: HOST,
       }),
       isAuthed: true,
-
     });
-
   };
 
- 
   const logout = async () => {
     handleClose();
-    await authClient.logout();
+    await authClient?.logout();
     setAgent({ agent: null });
-    navigate("/", { replace: true });
+    navigate("/market", { replace: true });
   };
 
+  const isActive = (path: string) => {
+    if (path === '/market') {
+      return location.pathname === '/market' || location.pathname.startsWith('/item/');
+    }
+    return location.pathname === path;
+  };
+
+  const desktopTabClass = (path: string) =>
+    `rounded-lg px-3 py-1.5 text-xs font-bold uppercase tracking-wide transition ${
+      isActive(path)
+        ? 'bg-white text-slate-900 shadow-sm'
+        : 'text-slate-600 hover:text-slate-900'
+    }`;
+
+  const mobileTabClass = (path: string) =>
+    `flex min-w-0 flex-1 flex-col items-center justify-center rounded-xl px-1 py-2 text-[10px] font-bold uppercase tracking-wide transition ${
+      isActive(path)
+        ? 'bg-slate-900 text-white shadow-sm'
+        : 'text-slate-600'
+    }`;
 
   return (
     <>
@@ -126,42 +116,22 @@ const Header: FC = () => {
             </span>
           </button>
 
-          <nav className="hidden items-center gap-1 rounded-xl bg-slate-100/80 p-1 md:flex">
-            <button
-              type="button"
-              onClick={openShop}
-              className={`rounded-lg px-3 py-1.5 text-xs font-bold uppercase tracking-wide transition ${menu == MENU_HOME ? 'bg-white text-slate-900 shadow-sm' : 'text-slate-600 hover:text-slate-900'}`}
-            >
+          <nav className="hidden items-center gap-1 rounded-xl bg-slate-100/80 p-1 md:flex" aria-label="Primary navigation">
+            <button type="button" onClick={openShop} className={desktopTabClass('/market')}>
               Market
             </button>
-            <button
-              type="button"
-              onClick={openFreeItems}
-              className={`rounded-lg px-3 py-1.5 text-xs font-bold uppercase tracking-wide transition ${menu == MENU_FREE ? 'bg-white text-slate-900 shadow-sm' : 'text-slate-600 hover:text-slate-900'}`}
-            >
-              Free 
+            <button type="button" onClick={openFreeItems} className={desktopTabClass('/free')}>
+              Free
             </button>
             {isAuthed && (
               <>
-                <button
-                  type="button"
-                  onClick={openOrders}
-                  className={`rounded-lg px-3 py-1.5 text-xs font-bold uppercase tracking-wide transition ${menu == MENU_ORDERS ? 'bg-white text-slate-900 shadow-sm' : 'text-slate-600 hover:text-slate-900'}`}
-                >
+                <button type="button" onClick={openOrders} className={desktopTabClass('/orders')}>
                   Orders
                 </button>
-                <button
-                  type="button"
-                  onClick={openMyItems}
-                  className={`rounded-lg px-3 py-1.5 text-xs font-bold uppercase tracking-wide transition ${menu == MENU_MY_ITEMS ? 'bg-white text-slate-900 shadow-sm' : 'text-slate-600 hover:text-slate-900'}`}
-                >
+                <button type="button" onClick={openMyItems} className={desktopTabClass('/items')}>
                   My Items
                 </button>
-                <button
-                  type="button"
-                  onClick={openProfile}
-                  className={`rounded-lg px-3 py-1.5 text-xs font-bold uppercase tracking-wide transition ${menu == MENU_PROFILE ? 'bg-white text-slate-900 shadow-sm' : 'text-slate-600 hover:text-slate-900'}`}
-                >
+                <button type="button" onClick={openProfile} className={desktopTabClass('/profile')}>
                   Profile
                 </button>
               </>
@@ -176,7 +146,9 @@ const Header: FC = () => {
               <button
                 type="button"
                 onClick={handleClick}
-                className="btn-modern-secondary rounded-full border border-slate-300/80 bg-white px-4 py-1.5 text-sm font-semibold text-slate-700 shadow-sm"
+                className="btn-modern-secondary rounded-full border border-slate-300/80 bg-white px-3 py-1.5 text-sm font-semibold text-slate-700 shadow-sm sm:px-4"
+                aria-expanded={openMenu}
+                aria-label="Open account menu"
               >
                 {principal ? <PrincipalName principal={principal} /> : 'Account'}
               </button>
@@ -218,6 +190,37 @@ const Header: FC = () => {
           )}
         </div>
       </header>
+
+      <nav
+        className="fixed bottom-3 left-3 right-3 z-40 mx-auto flex max-w-lg items-center gap-1 rounded-2xl border border-white/70 bg-white/95 p-1.5 shadow-2xl backdrop-blur md:hidden"
+        aria-label="Mobile navigation"
+      >
+        <button type="button" onClick={openShop} className={mobileTabClass('/market')}>
+          <span className="mb-1 text-sm" aria-hidden="true">⌂</span>
+          Market
+        </button>
+        <button type="button" onClick={openFreeItems} className={mobileTabClass('/free')}>
+          <span className="mb-1 text-sm" aria-hidden="true">♡</span>
+          Free
+        </button>
+        {isAuthed && (
+          <>
+            <button type="button" onClick={openOrders} className={mobileTabClass('/orders')}>
+              <span className="mb-1 text-sm" aria-hidden="true">↔</span>
+              Orders
+            </button>
+            <button type="button" onClick={openMyItems} className={mobileTabClass('/items')}>
+              <span className="mb-1 text-sm" aria-hidden="true">□</span>
+              Items
+            </button>
+            <button type="button" onClick={openProfile} className={mobileTabClass('/profile')}>
+              <span className="mb-1 text-sm" aria-hidden="true">●</span>
+              Me
+            </button>
+          </>
+        )}
+      </nav>
+
       {loading && (
         <div className="fixed inset-0 z-[100000] flex items-center justify-center bg-black/40" onClick={handleClose}>
           <div className="h-10 w-10 animate-spin rounded-full border-4 border-white/40 border-t-white" />

--- a/frontend/lib/constants.ts
+++ b/frontend/lib/constants.ts
@@ -75,6 +75,12 @@ export const CANISTER_ESCROW = "oslfo-7iaaa-aaaag-qakra-cai";
 export const CANISTER_TREASURY = "gncpj-jyaaa-aaaan-qagta-cai";
 
 export const CANISTER_ATTENDNFT = "vjod3-4iaaa-aaaan-qaoeq-cai";
+export const CANISTER_ONEBLOCK = "nzxho-uqaaa-aaaak-adwxq-cai";
+export const CANISTER_ONEBLOCK_ASSET = "32pz7-5qaaa-aaaag-qacra-cai";
+export const CANISTER_ICM = "rzdlh-haaaa-aaaal-aab3q-cai";
+export const CANISTER_BACKUP = "ixuio-siaaa-aaaam-qacxq-cai";
+export const CANISTER_ICEVENT_STAGING = "owctf-4qaaa-aaaak-qaahq-cai";
+
 export const CANISTER_INFIDENZA = 'h7ecw-giaaa-aaaal-ab75a-cai';
 export const CANISTER_ICPLEDGER = "ryjl3-tyaaa-aaaaa-aaaba-cai";
 
@@ -87,11 +93,7 @@ export const CANISTER_INBOX_DEFAULT = "r6cnt-kyaaa-aaaal-aab3a-cai";
 
 export const CANISTER_CKETH_INDEXER = "bqzgt-iiaaa-aaaai-qpdoa-cai";
 
-export const CANISTER_ONEBLOCK = "nzxho-uqaaa-aaaak-adwxq-cai";
-export const CANISTER_ONEBLOCK_ASSET = "32pz7-5qaaa-aaaag-qacra-cai";
-export const CANISTER_ICM = "rzdlh-haaaa-aaaal-aab3q-cai";
-export const CANISTER_BACKUP = "ixuio-siaaa-aaaam-qacxq-cai";
-export const CANISTER_ICEVENT_STAGING = "owctf-4qaaa-aaaak-qaahq-cai";
+
 
 export const WHITELIST = [
   CANISTER_ICEVENT,

--- a/frontend/lib/constants.ts
+++ b/frontend/lib/constants.ts
@@ -75,12 +75,6 @@ export const CANISTER_ESCROW = "oslfo-7iaaa-aaaag-qakra-cai";
 export const CANISTER_TREASURY = "gncpj-jyaaa-aaaan-qagta-cai";
 
 export const CANISTER_ATTENDNFT = "vjod3-4iaaa-aaaan-qaoeq-cai";
-export const CANISTER_ONEBLOCK = "nzxho-uqaaa-aaaak-adwxq-cai";
-export const CANISTER_ONEBLOCK_ASSET = "32pz7-5qaaa-aaaag-qacra-cai";
-export const CANISTER_ICM = "rzdlh-haaaa-aaaal-aab3q-cai";
-export const CANISTER_BACKUP = "ixuio-siaaa-aaaam-qacxq-cai";
-export const CANISTER_ICEVENT_STAGING = "owctf-4qaaa-aaaak-qaahq-cai";
-
 export const CANISTER_INFIDENZA = 'h7ecw-giaaa-aaaal-ab75a-cai';
 export const CANISTER_ICPLEDGER = "ryjl3-tyaaa-aaaaa-aaaba-cai";
 
@@ -93,7 +87,11 @@ export const CANISTER_INBOX_DEFAULT = "r6cnt-kyaaa-aaaal-aab3a-cai";
 
 export const CANISTER_CKETH_INDEXER = "bqzgt-iiaaa-aaaai-qpdoa-cai";
 
-
+export const CANISTER_ONEBLOCK = "nzxho-uqaaa-aaaak-adwxq-cai";
+export const CANISTER_ONEBLOCK_ASSET = "32pz7-5qaaa-aaaag-qacra-cai";
+export const CANISTER_ICM = "rzdlh-haaaa-aaaal-aab3q-cai";
+export const CANISTER_BACKUP = "ixuio-siaaa-aaaam-qacxq-cai";
+export const CANISTER_ICEVENT_STAGING = "owctf-4qaaa-aaaak-qaahq-cai";
 
 export const WHITELIST = [
   CANISTER_ICEVENT,
@@ -106,6 +104,7 @@ export const WHITELIST = [
   CANISTER_LEDGER,
   'gncpj-jyaaa-aaaan-qagta-cai',
   CANISTER_ESCROW,
+  CANISTER_ONEBLOCK,
   CANISTER_TREASURY,
   CANISTER_ATTENDNFT,
   CANISTER_INFIDENZA,

--- a/frontend/pages/Item.tsx
+++ b/frontend/pages/Item.tsx
@@ -1,39 +1,31 @@
 import * as React from 'react';
-
 import { useNavigate, useParams } from "react-router-dom";
-import { useEscrow, useMenu } from '../components/Store';
+import { useEscrow } from '../components/Store';
 import OfferDetail from '../components/offers/OfferDetail';
 import { Item } from 'frontend/api/escrow/service.did';
-import { MENU_HOME } from '../lib/constants';
 
-
-
-export default (props) => {
+export default () => {
     const escrow = useEscrow();
     const navigate = useNavigate();
-    const { setMenu } = useMenu();
-    const params =  useParams();
+    const params = useParams();
 
-    const [offer, setOffer] = React.useState<Item|null>();
+    const [offer, setOffer] = React.useState<Item | null>();
 
-    React.useEffect(()=>{
-        escrow.getItem(BigInt(params.id)).then(res=>{
+    React.useEffect(() => {
+        escrow.getItem(BigInt(params.id)).then(res => {
             setOffer(res[0]);
-        }); 
-    },[])
-  
+        });
+    }, []);
+
     return (
         <section className="mt-4 space-y-4">
             <div className="glass-panel rounded-2xl p-3 sm:p-4">
                 <button
                     type="button"
-                    onClick={() => {
-                        setMenu(MENU_HOME);
-                        navigate('/');
-                    }}
+                    onClick={() => navigate('/market')}
                     className="rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm font-semibold text-slate-700 transition hover:border-orange-500 hover:text-orange-700"
                 >
-                    Back to Marketplace
+                    ← Back to Marketplace
                 </button>
                 <p className="mt-2 text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">Product Detail</p>
             </div>


### PR DESCRIPTION
## Summary

This PR improves the highest-impact Vansday / ICEscrow frontend flows without changing the Motoko escrow state machine.

The UX goal is to make the protocol feel like a guided marketplace transaction: users see what they need to do next, can search the full marketplace, create listings in a short guided flow, and choose counterparties by profile instead of copying Principals.

## Phase 1 — navigation and escrow action center

- replace menu-state navigation with real routes: `/market`, `/free`, `/orders`, `/items`, `/profile`
- add a mobile bottom navigation so the main product areas remain reachable on small screens
- turn Orders into an action center with `Needs You`, `Waiting`, and completion summaries
- prioritize orders that require the signed-in user's next action
- clarify escrow action copy for deposit, delivery, receipt, release, and close
- restrict `Close Order` to appropriate stages instead of showing it on nearly every active seller order
- redirect successful paid orders and free-item claims into Orders so users can continue the workflow
- replace marketplace Previous/Next pagination with cumulative `Load More Listings`
- change the default new-listing type from NFT to Merchandise
- preserve deep links such as `/orders` during identity session restoration

## Phase 2 — marketplace discovery and creation

- wire marketplace search to the existing `searchItemsWithAssociations` backend query
- search across the full collection instead of only the currently loaded page
- include associated service/provider metadata in marketplace search results
- debounce search and guard against stale responses so fast query changes cannot overwrite newer results
- redesign listing creation into three steps: What → Terms → Review
- keep advanced service metadata collapsed under `More service details`
- add a Oneblock-backed counterparty picker for custom escrow orders
- allow lookup by profile name or `@profile` id and keep raw Principal entry under an Advanced fallback
- safely handle delayed identity restoration instead of assuming a Principal exists during initial render
- add `CANISTER_ONEBLOCK` to the Plug whitelist so profile search works for Plug-authenticated users

## Self-review fixes

During code-level review I also fixed:

- authenticated deep-link restoration
- overly broad seller `Close` controls
- canister result checks that could misread `ok = 0` as failure
- marketplace search loading races
- stale Principal state when changing counterparty search text
- premature `No matching profile` feedback before a search completes
- unnecessary constants-file churn; the final whitelist diff only adds Oneblock

## Scope

Frontend only. No Motoko escrow lifecycle, ledger, or stable-memory behavior is changed.

## Validation

- reviewed the full PR diff and generated frontend Candid bindings
- confirmed `searchItemsWithAssociations`, `searchProfilesByName`, `getProfile`, and `getProfileByPrincipal` exist in the current generated bindings
- GitHub reports the PR as mergeable
- this repository currently exposes no CI status checks for the branch
- a local `npm run build` could not be executed in the current execution sandbox because outbound GitHub DNS resolution is unavailable, so the PR remains Draft pending a normal local/CI build